### PR TITLE
fix(ci): stabilize CI across all platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Alire
-        uses: alire-project/setup-alire@v4
+        uses: alire-project/setup-alire@v5
 
-      - name: Build
-        run: alr build
+      - name: Build (no LAL)
+        run: alr -n build -- -XENRICH=no
 
       - name: Verify --help (Unix)
         if: runner.os != 'Windows'

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,10 @@ tests/fixtures/*/bin/
 tests/fixtures/*/lib/
 tests/fixtures/*/index.scip
 tests/fixtures/*/snapshot_new/
+
+# Un-ignore unit test fixture data
+!tests/fixtures/*.ali
+!tests/fixtures/project_fixture/obj/
+!tests/fixtures/project_fixture/obj/*.ali
+!tests/fixtures/project_fixture/lib/
+!tests/fixtures/project_fixture/lib/*.ads

--- a/alire.toml
+++ b/alire.toml
@@ -13,5 +13,3 @@ executables = ["scip_ada"]
 [[depends-on]]
 aunit = "^26.0.0"
 
-[[depends-on]]
-libadalang = "*"

--- a/scip_ada.gpr
+++ b/scip_ada.gpr
@@ -1,5 +1,4 @@
 with "config/scip_ada_config.gpr";
-with "libadalang.gpr";
 project Scip_Ada is
 
    type Enrich_Mode is ("yes", "no");
@@ -36,13 +35,10 @@ project Scip_Ada is
    end Binder;
 
    package Linker is
-      for Switches ("Ada") use
-        ("-lgnarl", "-Wno-overriding-deployment-version");
+      for Switches ("Ada") use ("-lgnarl");
       case Scip_Ada_Config.Build_Profile is
          when "release" =>
-            for Switches ("Ada") use
-              ("-lgnarl", "-static",
-               "-Wno-overriding-deployment-version");
+            for Switches ("Ada") use ("-lgnarl", "-static");
          when others =>
             null;
       end case;

--- a/tests/fixtures/basic.ali
+++ b/tests/fixtures/basic.ali
@@ -1,0 +1,19 @@
+V "GNAT Lib v2024"
+A -gnatA
+P ZX
+
+U hello%shello.adsabc123 EE NE
+W system%ssystem.adssystem.ali
+
+D hello.ads 20240101120000 abc123 hello
+D hello.adb 20240101120001 def456 hello
+D system.ads 20240101120000 789abc system%s
+
+X 1 hello.ads
+5K9*Hello 6e13 2|3b7 2|11l8
+7U14*Say_Hello 2|5b14 2|9s14
+9I9*Count 10r5 2|7m9
+X 2 hello.adb
+3K9 Hello 11l8
+5U14 Say_Hello 9s14
+7i9 Count

--- a/tests/fixtures/continuation.ali
+++ b/tests/fixtures/continuation.ali
@@ -1,0 +1,22 @@
+V "GNAT Lib v2024"
+A -gnatA
+P ZX
+
+U big_pkg%s big_pkg.ads abc123 EE NE
+
+D big_pkg.ads 20240101120000 aaa111 big_pkg
+D big_pkg.adb 20240101120001 bbb222 big_pkg
+D client1.adb 20240101120002 ccc333 client1
+D client2.adb 20240101120003 ddd444 client2
+D system.ads 20240101120000 eee555 system%s
+
+X 1 big_pkg.ads
+3K9*Big_Pkg 4e11 2|3b7 2|50l8
+5I9*Important_Type 2|5r9 2|10r9 2|15r9 2|20r9
+. 2|25r9 2|30r9 3|5r9 3|10r9
+. 3|15r9 4|5r9 4|10r9 4|15r9
+7U14*Widely_Used 2|7b14 2|12s14 2|22s14
+. 2|32s14 3|7s14 3|12s14
+. 4|7s14 4|12s14
+X 2 big_pkg.adb
+3K9 Big_Pkg 50l8

--- a/tests/fixtures/generics.ali
+++ b/tests/fixtures/generics.ali
@@ -1,0 +1,31 @@
+V "GNAT Lib v2024"
+A -gnatA
+P ZX
+
+U generic_stack%s generic_stack.ads abc123 GE NE
+W system%s system.ads system.ali
+
+D generic_stack.ads 20240101120000 aaa111 generic_stack
+D generic_stack.adb 20240101120001 bbb222 generic_stack
+D int_stack.ads 20240101120002 ccc333 int_stack
+D system.ads 20240101120000 ddd444 system%s
+
+X 1 generic_stack.ads
+3G9*Generic_Stack 4e18 2|3b7 2|25l8
+5+9*Element_Type
+7R9*Stack 2|5r9 8c9 3|4r9
+8C9 Data 11r12
+9I9*Top 12m9 2|10r9 2|15m9
+11U14*Push 2|8b14 2|18s14
+13V14*Pop 2|12b14 2|22s14
+15V14*Is_Empty 2|16b14
+X 2 generic_stack.adb
+3G9 Generic_Stack 25l8
+5r9 Stack
+8U14 Push 18s14
+12V14 Pop 22s14
+16V14 Is_Empty
+X 3 int_stack.ads
+2K9*Int_Stack 4l8
+3k9*My_Stack[1|3{1|3}]
+4r9 Stack

--- a/tests/fixtures/gnat_sample.ali
+++ b/tests/fixtures/gnat_sample.ali
@@ -1,0 +1,124 @@
+V "GNAT Lib v15"
+A -gnatws
+A -mmacosx-version-min=16.0.0
+A -mcpu=apple-m1
+A -mlittle-endian
+A -mabi=lp64
+A -fPIC
+P SS ZX
+
+RN
+RV NO_DISPATCHING_CALLS
+RV NO_FLOATING_POINT
+RV NO_IO
+RV NO_IMPLICIT_CONDITIONALS
+RV NO_SECONDARY_STACK
+RV NO_STANDARD_STORAGE_POOLS
+RV NO_IMPLEMENTATION_PRAGMAS
+RV NO_ELABORATION_CODE
+
+U sample%b		sample.adb		0a2fb4dc OO PK
+W ada%s			ada.ads			ada.ali
+Z ada.strings.text_buffers%s  a-sttebu.adb	a-sttebu.ali
+W ada.text_io%s		a-textio.adb		a-textio.ali
+
+U sample%s		sample.ads		d5315d64 BN EE OO PF PK
+Z ada.exceptions%s	a-except.adb		a-except.ali
+Z ada.streams%s		a-stream.adb		a-stream.ali
+Z ada.strings.text_buffers%s  a-sttebu.adb	a-sttebu.ali
+Z ada.tags%s		a-tags.adb		a-tags.ali
+Z system%s		system.ads		system.ali
+Z system.put_images%s	s-putima.adb		s-putima.ali
+Z system.return_stack%s	s-retsta.ads		s-retsta.ali
+Z system.secondary_stack%s  s-secsta.adb	s-secsta.ali
+Z system.stream_attributes%s  s-stratt.adb	s-stratt.ali
+
+D ada.ads		20250419085653 76789da1 ada%s
+D a-except.ads		20250419085653 e7970cd9 ada.exceptions%s
+D a-ioexce.ads		20250419085653 40018c65 ada.io_exceptions%s
+D a-stream.ads		20250419085653 17477cbd ada.streams%s
+D a-string.ads		20250419085653 90ac6797 ada.strings%s
+D a-sttebu.ads		20250419085653 f1ad67a2 ada.strings.text_buffers%s
+D a-stuten.ads		20250419085653 c6ced0ae ada.strings.utf_encoding%s
+D a-tags.ads		20250419085653 fbca0ad5 ada.tags%s
+D a-textio.ads		20250419085653 34ef47de ada.text_io%s
+D a-unccon.ads		20250419085653 0e9b276f ada.unchecked_conversion%s
+D interfac.ads		20250419085653 9111f9c1 interfaces%s
+D i-cstrea.ads		20250419085653 ffd01b9d interfaces.c_streams%s
+D sample.ads		20260322034400 d5315d64 sample%s
+D sample.adb		20260322034407 ebf1ae66 sample%b
+D system.ads		20250419085653 70765b54 system%s
+D s-crtl.ads		20250419085653 beb39b9e system.crtl%s
+D s-exctab.ads		20250419085653 91bef6ef system.exception_table%s
+D s-ficobl.ads		20250419085653 dc5161d4 system.file_control_block%s
+D s-parame.ads		20250419085653 3597fc11 system.parameters%s
+D s-putima.ads		20250419085653 17291fe4 system.put_images%s
+D s-retsta.ads		20250419085653 0f6b06cb system.return_stack%s
+D s-secsta.ads		20250419085653 578279f5 system.secondary_stack%s
+D s-soflin.ads		20250419085653 5d88fdea system.soft_links%s
+D s-stache.ads		20250419085653 0b81c1fe system.stack_checking%s
+D s-stalib.ads		20250419085653 1c9580f6 system.standard_library%s
+D s-stoele.ads		20250419085653 ccded4e8 system.storage_elements%s
+D s-stratt.ads		20250419085653 516607ae system.stream_attributes%s
+D s-traent.ads		20250419085653 c81cbf8c system.traceback_entries%s
+D s-unstyp.ads		20250419085653 fa2a7f59 system.unsigned_types%s
+D s-wchcon.ads		20250419085653 d9032363 system.wch_con%s
+G a e
+G c Z s b [area sample 14 13 none]
+G c Z s b [draw sample 15 14 none]
+G c Z s s [pointIP sample 5 9 none]
+G c Z s s [shapeDA sample 10 9 none]
+G c Z s s [shapeDF sample 10 9 none]
+G c Z s s [shapeIP sample 10 9 none]
+G c Z s b [area sample 21 24 none]
+G c Z s b [draw sample 22 25 none]
+G c Z s b [Oadd sample 33 13 none]
+G c Z s s [circleDA sample 17 9 none]
+G c Z s s [circleDF sample 17 9 none]
+G c Z s s [circleIP sample 17 9 none]
+G c Z s s [int_arrayIP sample 37 9 none]
+X 1 ada.ads
+18K9*Ada 22e8 14|1r6 14r7 25r7
+X 9 a-textio.ads
+58K13*Text_IO 785e16 14|1w10 14r11 25r11
+565U14*Put_Line 14|14s19 25s19
+X 13 sample.ads
+1K9*Sample 43l5 43e11 14|3b14 56l5 56t11
+3E9*Color 3e36 41r20
+3n19*Red{3E9} 41r29
+3n24*Green{3E9}
+3n31*Blue{3E9}
+5R9*Point 8e14 11r16 33r25 33r39 35r26 14|51r25 51r39
+6i7*X{integer} 35m36 14|53m15 53r22 53r28
+7i7*Y{integer} 35m44 14|53m31 53r38 53r44
+10R9*Shape 12e14 14p13 14r23 15p14 15r24 17r23 14|5r23 11r24
+11r7*Origin{5R9}
+14V13*Area{float} 14>19 14|5b13 9l8 9t12
+14r19 S{10R9} 14|5b19 6r28
+15U14*Draw 15>20 14|11b14 15l8 15t12
+15r20 S{10R9} 14|11b20 12r28
+17R9*Circle<10R9> 19e14 21P24 21r34 22P25 22r35 14|17r34 22r35
+18f7*Radius{float} 14|19r26 19r37
+21V24*Area{float}<14p13> 21>30 14|17b24 20l8 20t12
+21r30 C{17R9} 14|17b30 19r24 19r35
+22U25*Draw<15p14> 22>31 14|22b25 26l8 26t12
+22r31 C{17R9} 14|22b31 23r28
+25+12 Element_Type 28r30 29r27 14|29r36 32r30 38r27 39r28
+26i7 Size{positive} 14|29r27
+27k12*Bounded_Stack 25z12 26z7 31l8 31e21 14|28b17 49l8 49t21
+28U17*Push 28>23 14|32b17 36l11 36t15
+28*23 Item{25+12} 14|32b23 35r25
+29V16*Pop{25+12} 14|38b16 43l11 43t14
+30V16*Is_Empty{boolean} 14|45b16 48l11 48t19
+33V14*"+"{5R9} 33>18 33>21 14|51b14 54l9 54t11
+33r18 L{5R9} 14|51b18 53r20 53r36
+33r21 R{5R9} 14|51b21 53r26 53r42
+35r4*Null_Point{5R9}
+37A9*Int_Array(integer)<integer>
+39I12*Small_Int{integer}
+41e4*Default_Color{3E9}
+X 14 sample.adb
+29a7 Stack(13|25+12) 35m10 39r44
+30i7 Top{natural} 34m10 34r17 35r17 39r51 41m10 41r17 47r17
+39*10 Result{13|25+12} 42r17
+

--- a/tests/fixtures/gnat_sample_main.ali
+++ b/tests/fixtures/gnat_sample_main.ali
@@ -1,0 +1,74 @@
+V "GNAT Lib v15"
+M P W=b
+A -gnatws
+A -mmacosx-version-min=16.0.0
+A -mcpu=apple-m1
+A -mlittle-endian
+A -mabi=lp64
+A -fPIC
+P SS ZX
+
+RN
+RV NO_FLOATING_POINT
+RV NO_STANDARD_STORAGE_POOLS
+RV NO_DEFAULT_INITIALIZATION
+
+U sample_main%b		sample_main.adb		197d8dfd NE OO SU
+Z ada.strings.text_buffers%s  a-sttebu.adb	a-sttebu.ali
+Z ada.tags%s		a-tags.adb		a-tags.ali
+W sample%s		sample.adb		sample.ali
+
+D ada.ads		20250419085653 76789da1 ada%s
+D a-except.ads		20250419085653 e7970cd9 ada.exceptions%s
+D a-stream.ads		20250419085653 17477cbd ada.streams%s
+D a-string.ads		20250419085653 90ac6797 ada.strings%s
+D a-sttebu.ads		20250419085653 f1ad67a2 ada.strings.text_buffers%s
+D a-stuten.ads		20250419085653 c6ced0ae ada.strings.utf_encoding%s
+D a-tags.ads		20250419085653 fbca0ad5 ada.tags%s
+D a-unccon.ads		20250419085653 0e9b276f ada.unchecked_conversion%s
+D interfac.ads		20250419085653 9111f9c1 interfaces%s
+D sample.ads		20260322034400 d5315d64 sample%s
+D sample_main.adb	20260322034414 cc4cd099 sample_main%b
+D system.ads		20250419085653 70765b54 system%s
+D s-exctab.ads		20250419085653 91bef6ef system.exception_table%s
+D s-parame.ads		20250419085653 3597fc11 system.parameters%s
+D s-putima.ads		20250419085653 17291fe4 system.put_images%s
+D s-retsta.ads		20250419085653 0f6b06cb system.return_stack%s
+D s-secsta.ads		20250419085653 578279f5 system.secondary_stack%s
+D s-soflin.ads		20250419085653 5d88fdea system.soft_links%s
+D s-stache.ads		20250419085653 0b81c1fe system.stack_checking%s
+D s-stalib.ads		20250419085653 1c9580f6 system.standard_library%s
+D s-stoele.ads		20250419085653 ccded4e8 system.storage_elements%s
+D s-stratt.ads		20250419085653 516607ae system.stream_attributes%s
+D s-traent.ads		20250419085653 c81cbf8c system.traceback_entries%s
+D s-unstyp.ads		20250419085653 fa2a7f59 system.unsigned_types%s
+G a e
+G c Z b b [sample_main standard 3 11 none]
+G r s shape [sample_main standard 3 11 none] [shapeIP sample 10 9 none]
+G r s circle [sample_main standard 3 11 none] [circleIP sample 17 9 none]
+G r c none [sample_main standard 3 11 none] [Oadd sample 33 13 none]
+G r c none [sample_main standard 3 11 none] [draw sample 15 14 none]
+G r c none [sample_main standard 3 11 none] [area sample 14 13 none]
+G r c none [sample_main standard 3 11 none] [area sample 21 24 none]
+X 10 sample.ads
+1K9*Sample 43e11 11|1w6 4r9 5r9 6r9 7r9 8r9 11r10 13r4 14r9 16r4 16r17 17r9
+5R9*Point 8e14 11|4r16 5r16 6r16
+6i7*X{integer} 11|4m26 5m26
+7i7*Y{integer} 11|4m34 5m34
+10R9*Shape 12e14 11|7r16 16r24
+11r7*Origin{5R9} 11|12m6 15m10
+14V13*Area{float} 11|14s16
+15U14*Draw 11|13s11 16s11
+17R9*Circle<10R9> 19e14 11|8r16
+18f7*Radius{float} 11|15m24
+21V24*Area{float}<14p13> 11|17s16
+33V14*"+"{5R9} 11|11s18
+X 11 sample_main.adb
+3U11*Sample_Main 3b11 18l5 18t16
+4r4 P1{10|5R9} 11r22 12r16 15r20
+5r4 P2{10|5R9} 11r26
+6r4 P3{10|5R9} 11m4
+7r4 S{10|10R9} 12m4 13r17 14r22
+8r4 C{10|17R9} 15m4 16r31 17r22
+9f4 A{float} 14m4 17m4
+

--- a/tests/fixtures/operators.ali
+++ b/tests/fixtures/operators.ali
@@ -1,0 +1,26 @@
+V "GNAT Lib v2024"
+A -gnatA
+P ZX
+
+U vectors%s vectors.ads abc123 EE NE
+
+D vectors.ads 20240101120000 aaa111 vectors
+D vectors.adb 20240101120001 bbb222 vectors
+D system.ads 20240101120000 ccc333 system%s
+
+X 1 vectors.ads
+3K9*Vectors 4e11 2|3b7 2|40l8
+5R9*Vec2 7c9
+6C9 X
+7C9 Y
+9V14*"+" 2|5b14 2|20s14
+10V14*"-" 2|7b14 2|22s14
+11V14*"*" 2|9b14 2|25s14
+12V14*"=" 2|11b14
+14I9*Dimension 15r9
+X 2 vectors.adb
+3K9 Vectors 40l8
+5V14 "+"
+7V14 "-"
+9V14 "*"
+11V14 "="

--- a/tests/fixtures/overloaded.ali
+++ b/tests/fixtures/overloaded.ali
@@ -1,0 +1,26 @@
+V "GNAT Lib v2024"
+A -gnatA
+P ZX
+
+U math_ops%s math_ops.ads abc123 EE NE
+
+D math_ops.ads 20240101120000 aaa111 math_ops
+D math_ops.adb 20240101120001 bbb222 math_ops
+D system.ads 20240101120000 ccc333 system%s
+
+X 1 math_ops.ads
+3K9*Math_Ops 4e12 2|3b7 2|35l8
+5V14*Add 2|5b14 2|10s14
+6V14*Add 2|7b14 2|15s14
+7V14*Add 2|9b14 2|20s14
+9U14*Process 2|12b14
+10U14*Process 2|14b14
+12I9*Result_Type 15r9
+13F9*Float_Result 16r9
+X 2 math_ops.adb
+3K9 Math_Ops 35l8
+5V14 Add
+7V14 Add
+9V14 Add
+12U14 Process
+14U14 Process

--- a/tests/fixtures/project_fixture/lib/utils.ads
+++ b/tests/fixtures/project_fixture/lib/utils.ads
@@ -1,0 +1,3 @@
+package Utils is
+   function Add (A, B : Integer) return Integer;
+end Utils;

--- a/tests/fixtures/project_fixture/obj/main.ali
+++ b/tests/fixtures/project_fixture/obj/main.ali
@@ -1,0 +1,13 @@
+V "GNAT Lib v2024"
+A -gnatA
+P ZX
+
+U main%s		main.ads		abc123 EE NE
+
+D main.ads		20240101120000 abc123 main
+D utils.ads		20240101120000 def456 utils
+
+X 1 main.ads
+2U14*Run 3e5
+X 2 utils.ads
+2V14*Add 3r5

--- a/tests/fixtures/project_fixture/obj/utils.ali
+++ b/tests/fixtures/project_fixture/obj/utils.ali
@@ -1,0 +1,10 @@
+V "GNAT Lib v2024"
+A -gnatA
+P ZX
+
+U utils%s		utils.ads		def456 EE NE
+
+D utils.ads		20240101120000 def456 utils
+
+X 1 utils.ads
+2V14*Add

--- a/tests/fixtures/renaming.ali
+++ b/tests/fixtures/renaming.ali
@@ -1,0 +1,19 @@
+V "GNAT Lib v2024"
+A -gnatA
+P ZX
+
+U renaming_example%s renaming_example.ads abc123 EE NE
+
+D renaming_example.ads 20240101120000 aaa111 renaming_example
+D renaming_example.adb 20240101120001 bbb222 renaming_example
+D system.ads 20240101120000 ccc333 system%s
+
+X 1 renaming_example.ads
+3K9*Renaming_Example 4e20 2|3b7 2|20l8
+5U14*Original_Proc 2|5b14 2|10s14
+7U14*Renamed_Proc=Original_Proc 2|12s14
+9I9*Base_Count 2|7r9
+10i9*Alias_Count=Base_Count 2|8r9
+X 2 renaming_example.adb
+3K9 Renaming_Example 20l8
+5U14 Original_Proc

--- a/tests/fixtures/tagged_types.ali
+++ b/tests/fixtures/tagged_types.ali
@@ -1,0 +1,130 @@
+V "GNAT Lib v15"
+A -gnatA
+A -mmacosx-version-min=16.0.0
+A -mcpu=apple-m1
+A -mlittle-endian
+A -mabi=lp64
+A -fPIC
+P SS ZX
+
+RN
+RV NO_DISPATCH
+RV NO_DISPATCHING_CALLS
+RV NO_EXCEPTION_HANDLERS
+RV NO_EXCEPTIONS
+RV NO_FLOATING_POINT
+RV NO_IO
+RV NO_IMPLICIT_CONDITIONALS
+RV NO_SECONDARY_STACK
+RV NO_STANDARD_STORAGE_POOLS
+RV NO_IMPLEMENTATION_PRAGMAS
+RV NO_ELABORATION_CODE
+
+U shapes%b		shapes.adb		89ac2507 OO PK
+W ada%s			ada.ads			ada.ali
+Z ada.strings.text_buffers%s  a-sttebu.adb	a-sttebu.ali
+W ada.text_io%s		a-textio.adb		a-textio.ali
+
+U shapes%s		shapes.ads		3aca7651 EE OO PF PK
+Z ada.exceptions%s	a-except.adb		a-except.ali
+Z ada.streams%s		a-stream.adb		a-stream.ali
+Z ada.strings.text_buffers%s  a-sttebu.adb	a-sttebu.ali
+Z ada.tags%s		a-tags.adb		a-tags.ali
+Z system%s		system.ads		system.ali
+Z system.finalization_primitives%s  s-finpri.adb  s-finpri.ali
+Z system.pool_global%s	s-pooglo.adb		s-pooglo.ali
+Z system.put_images%s	s-putima.adb		s-putima.ali
+Z system.return_stack%s	s-retsta.ads		s-retsta.ali
+Z system.secondary_stack%s  s-secsta.adb	s-secsta.ali
+Z system.soft_links%s	s-soflin.adb		s-soflin.ali
+Z system.stream_attributes%s  s-stratt.adb	s-stratt.ali
+
+D ada.ads		20250419085653 76789da1 ada%s
+D a-except.ads		20250419085653 e7970cd9 ada.exceptions%s
+D a-finali.ads		20250419085653 bf4f806b ada.finalization%s
+D a-ioexce.ads		20250419085653 40018c65 ada.io_exceptions%s
+D a-stream.ads		20250419085653 17477cbd ada.streams%s
+D a-string.ads		20250419085653 90ac6797 ada.strings%s
+D a-sttebu.ads		20250419085653 f1ad67a2 ada.strings.text_buffers%s
+D a-stuten.ads		20250419085653 c6ced0ae ada.strings.utf_encoding%s
+D a-tags.ads		20250419085653 fbca0ad5 ada.tags%s
+D a-textio.ads		20250419085653 34ef47de ada.text_io%s
+D a-unccon.ads		20250419085653 0e9b276f ada.unchecked_conversion%s
+D interfac.ads		20250419085653 9111f9c1 interfaces%s
+D i-c.ads		20250419085653 e94c966a interfaces.c%s
+D i-cstrea.ads		20250419085653 ffd01b9d interfaces.c_streams%s
+D shapes.ads		20260322082138 3aca7651 shapes%s
+D shapes.adb		20260322082143 87891488 shapes%b
+D system.ads		20250419085653 70765b54 system%s
+D s-crtl.ads		20250419085653 beb39b9e system.crtl%s
+D s-exctab.ads		20250419085653 91bef6ef system.exception_table%s
+D s-ficobl.ads		20250419085653 dc5161d4 system.file_control_block%s
+D s-finpri.ads		20250419085653 5970d55a system.finalization_primitives%s
+D s-finroo.ads		20250419085653 0a7c3ed4 system.finalization_root%s
+D s-oscons.ads		20250522142959 16132a6a system.os_constants%s
+D s-oslock.ads		20250419085653 13fa6b78 system.os_locks%s
+D s-parame.ads		20250419085653 3597fc11 system.parameters%s
+D s-pooglo.ads		20250419085653 91708d21 system.pool_global%s
+D s-putima.ads		20250419085653 17291fe4 system.put_images%s
+D s-retsta.ads		20250419085653 0f6b06cb system.return_stack%s
+D s-secsta.ads		20250419085653 578279f5 system.secondary_stack%s
+D s-soflin.ads		20250419085653 5d88fdea system.soft_links%s
+D s-stache.ads		20250419085653 0b81c1fe system.stack_checking%s
+D s-stalib.ads		20250419085653 1c9580f6 system.standard_library%s
+D s-stoele.ads		20250419085653 ccded4e8 system.storage_elements%s
+D s-stopoo.ads		20250419085653 e9fa2dd8 system.storage_pools%s
+D s-stratt.ads		20250419085653 516607ae system.stream_attributes%s
+D s-traent.ads		20250419085653 c81cbf8c system.traceback_entries%s
+D s-unstyp.ads		20250419085653 fa2a7f59 system.unsigned_types%s
+D s-wchcon.ads		20250419085653 d9032363 system.wch_con%s
+G a e
+G c Z s b [move shapes 18 14 none]
+G c Z s s [shapeDA shapes 10 9 none]
+G c Z s s [shapeDF shapes 10 9 none]
+G c Z s s [shapeIP shapes 10 9 none]
+G c Z s b [area shapes 28 24 none]
+G c Z s b [draw shapes 29 25 none]
+G c Z s b [area shapes 36 24 none]
+G c Z s s [circleDA shapes 24 9 none]
+G c Z s s [circleDF shapes 24 9 none]
+G c Z s s [circleIP shapes 24 9 none]
+G c Z s s [rectangleDA shapes 31 9 none]
+G c Z s s [rectangleDF shapes 31 9 none]
+G c Z s s [rectangleIP shapes 31 9 none]
+X 1 ada.ads
+18K9*Ada 22e8 16|1r6 18r7
+X 10 a-textio.ads
+58K13*Text_IO 785e16 16|1w10 18r11
+565U14*Put_Line 16|18s19
+X 15 shapes.ads
+2K9*Shapes 37l5 37e11 16|3b14 25l5 25t11
+4h9*Drawable
+4r9 Drawable{4R9}
+4r9 Drawable{4R9}
+4h9*Drawable 7p14 7r24 24r33
+7x14*Draw 7>20
+7r20 D{4R9}
+10H9*Shape 13e14 16p13 16r23 18p14 18r31 21r36 24r23 31r26 16|4r31
+11f7*X{float} 16|6m9 6r16
+12f7*Y{float} 16|7m9 7r16
+16y13*Area{float} 16>19
+16r19 S{10R9}
+18U14*Move 18=20 18>38 18>42 16|4b14 8l8 8t12
+18r20 S{10R9} 16|4b20 6m7 6r14 7m7 7r14
+18f38 DX{float} 16|4b38 6r20
+18f42 DY{float} 16|4b42 7r20
+21P9*Shape_Access(10R9)
+24R9*Circle<10R9><4R9> 18p14 26e14 28P24 28r34 29P25 29r35 16|10r34 16r35
+25f7*Radius{float} 16|13r21 13r32
+28V24*Area{float}<16p13> 28>30 16|10b24 14l8 14t12
+28r30 S{24R9} 16|10b30 13r19 13r30
+29U25*Draw<7p14> 29>31 16|16b25 19l8 19t12
+29r31 S{24R9} 16|16b31
+31R9*Rectangle<10R9> 18p14 34e14 36P24 36r34 16|21r34
+32f7*Width{float} 16|23r16
+33f7*Height{float} 16|23r26
+36V24*Area{float}<16p13> 36>30 16|21b24 24l8 24t12
+36r30 S{31R9} 16|21b30 23r14 23r24
+X 16 shapes.adb
+11f7 Pi{float} 13r14
+

--- a/tests/scip_ada_tests.gpr
+++ b/tests/scip_ada_tests.gpr
@@ -22,8 +22,7 @@ project Scip_Ada_Tests is
    end Binder;
 
    package Linker is
-      for Default_Switches ("Ada") use
-        ("-Wno-overriding-deployment-version");
+      for Default_Switches ("Ada") use ();
    end Linker;
 
 end Scip_Ada_Tests;


### PR DESCRIPTION
## Problem

CI was failing on all platforms with three distinct issues:

1. **macOS arm64 & Windows** — `alr build` failed because the auto-selected GNAT 14.2.1 toolchain couldn't resolve AUnit 26.0.0 (`missed:unavailable`), and on macOS the 14.x toolchain's `include-fixed/stdio.h` was incompatible with the runner OS headers
2. **Linux** — Main build passed but `Build tests` failed with `imported project file "aunit" not found` because the incomplete dependency solution didn't add AUnit to `GPR_PROJECT_PATH`
3. **All platforms** — The macOS-specific linker flag `-Wno-overriding-deployment-version` was used unconditionally, breaking non-macOS builds

Additionally, hand-crafted ALI test fixture files were excluded by the global `*.ali` gitignore pattern, so unit tests would always fail in a fresh checkout.

## Changes

- **Pin GNAT 15.1.2 toolchain** — available as binaries on all 4 CI platforms (Linux x86_64, macOS arm64, macOS x86_64, Windows x86_64)
- **Build with `ENRICH=no`** — skips libadalang (heavy source dep, fragile in CI); the unit tests already use `lal_stubs`
- **Remove `with "libadalang.gpr"` from `scip_ada.gpr`** — the Alire-generated `config/scip_ada_config.gpr` provides it transitively when developers add libadalang via `alr with libadalang`
- **Remove libadalang from base `alire.toml`** — developers re-add it for full LAL builds
- **Remove `-Wno-overriding-deployment-version`** — macOS-only linker flag that broke Linux/Windows
- **Track unit-test fixture files** — add `.gitignore` negation patterns for `tests/fixtures/*.ali` and `tests/fixtures/project_fixture/{obj,lib}/`

## Validation

- `alr build -- -XENRICH=no` passes locally (3s)
- `alr exec -- gprbuild -P tests/scip_ada_tests.gpr` passes
- `./bin/test_runner` — 34/34 tests pass
- Full LAL build (`alr build` with libadalang in alire.toml) still works via config GPR transitivity