### PR TITLE
ci(e2e): add E2E snapshot tests to CI and regenerate fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,18 @@ jobs:
       - name: Run tests (Windows)
         if: runner.os == 'Windows'
         run: .\bin\test_runner.exe
+
+      - name: Install scip CLI
+        if: runner.os == 'Linux'
+        run: |
+          mkdir -p "$HOME/bin"
+          SCIP_VERSION="v0.5.1"
+          curl -fsSL "https://github.com/sourcegraph/scip/releases/download/${SCIP_VERSION}/scip-linux-amd64.tar.gz" \
+            | tar xz -C "$HOME/bin"
+          chmod +x "$HOME/bin/scip"
+
+      - name: Run E2E snapshot tests
+        if: runner.os == 'Linux'
+        run: |
+          export PATH="$HOME/bin:$PATH"
+          bash tests/e2e_test.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           mkdir -p "$HOME/bin"
-          SCIP_VERSION="v0.5.1"
+          SCIP_VERSION="v0.6.1"
           curl -fsSL "https://github.com/sourcegraph/scip/releases/download/${SCIP_VERSION}/scip-linux-amd64.tar.gz" \
             | tar xz -C "$HOME/bin"
           chmod +x "$HOME/bin/scip"

--- a/tests/e2e_repos_test.sh
+++ b/tests/e2e_repos_test.sh
@@ -685,6 +685,141 @@ test_pragmarc() {
   rm -f "$index"
 }
 
+# ---------------------------------------------------------------------------
+# 4. mk270/whitakers-words — Latin dictionary (311 stars, ~112 source files)
+#    Highest-starred pure-Ada repo that builds standalone (no external deps).
+#    Note: AdaCore/gnatstudio is #1 by stars (497) but requires GNATCOLL,
+#    XMLAda, and many other external dependencies.
+# ---------------------------------------------------------------------------
+test_whitakers_words() {
+  local name="whitakers-words"
+  local url="https://github.com/mk270/whitakers-words.git"
+  local commit="9b11477e53f4adfb17d6f6aa563669dc71e0a680"
+  local repo_dir="$REPOS_DIR/$name"
+
+  log_section "$name — Latin dictionary (~112 source files, library projects)"
+
+  if ! clone_repo "$name" "$url" "$commit"; then
+    record_fail "$name/clone" "git clone failed"
+    return
+  fi
+
+  # Whitaker's Words uses a multi-project layout (shared.gpr, latin_utils.gpr,
+  # support_utils.gpr, words_engine.gpr, commands.gpr). Create a single
+  # wrapper GPR that pulls all source dirs together for indexing.
+  local gpr_path
+  gpr_path="$(write_wrapper_gpr "$repo_dir" "whitakers_words_scip" \
+    "src/latin_utils,src/support_utils,src/words_engine,src/commands")"
+  local gpr_rel
+  gpr_rel="$(basename "$gpr_path")"
+
+  log "Building with wrapper .gpr ..."
+  if ! (cd "$repo_dir" && gprbuild -P "$gpr_rel" -q -p -j0 2>&1); then
+    record_fail "$name/build" "gprbuild failed"
+    return
+  fi
+  record_pass "$name/build"
+
+  local index="$repo_dir/index.scip"
+  log "Indexing ..."
+  if ! (cd "$repo_dir" && "$SCIP_ADA" index \
+        --project "$gpr_rel" \
+        --output "$index" \
+        --exclude b__ \
+        --quiet 2>&1); then
+    record_fail "$name/index" "scip_ada index failed"
+    return
+  fi
+  record_pass "$name/index"
+
+  # --- Tier 1: Structural verifications ---
+  verify_metadata      "$name" "$index"
+  verify_no_empty_docs "$name" "$index"
+  verify_occurrence_ranges "$name" "$index"
+  verify_stats         "$name" "$index" 80 1000 5000
+
+  # --- Tier 2: Content verifications ---
+  verify_symbols       "$name" "$index" \
+    "Latin_Utils" "Words_Engine" "Inflections_Package" "Dictionary"
+  verify_doc_paths     "$name" "$index" ".ads" ".adb"
+  verify_symbols_have_info "$name" "$index"
+
+  # --- Tier 3: Integrity verifications ---
+  verify_xref_integrity   "$name" "$index"
+  verify_def_ref_balance  "$name" "$index"
+
+  rm -f "$index"
+}
+
+# ---------------------------------------------------------------------------
+# 5. rod-chapman/SPARKNaCl — SPARK 2014 NaCl crypto library (132 stars, ~50 files)
+#    Pure SPARK 2014 with formal verification contracts — exercises scip_ada on
+#    SPARK-specific constructs (pre/post conditions, ghost code, subtypes).
+# ---------------------------------------------------------------------------
+test_sparknacl() {
+  local name="SPARKNaCl"
+  local url="https://github.com/rod-chapman/SPARKNaCl.git"
+  local commit="8e3cc2e6a67826cbfb1e36559238e03cb024a706"
+  local repo_dir="$REPOS_DIR/$name"
+
+  log_section "$name — SPARK 2014 crypto library (~50 source files, formal verification)"
+
+  if ! clone_repo "$name" "$url" "$commit"; then
+    record_fail "$name/clone" "git clone failed"
+    return
+  fi
+
+  # SPARKNaCl ships sparknacl.gpr but it's a library project with external
+  # variables and a Prove package. Create a simple wrapper for indexing.
+  local gpr_path
+  gpr_path="$(write_wrapper_gpr "$repo_dir" "sparknacl_scip" "src")"
+  local gpr_rel
+  gpr_rel="$(basename "$gpr_path")"
+
+  log "Building with wrapper .gpr ..."
+  if ! (cd "$repo_dir" && gprbuild -P "$gpr_rel" -q -p -j0 2>&1); then
+    record_fail "$name/build" "gprbuild failed"
+    return
+  fi
+  record_pass "$name/build"
+
+  local index="$repo_dir/index.scip"
+  log "Indexing ..."
+  if ! (cd "$repo_dir" && "$SCIP_ADA" index \
+        --project "$gpr_rel" \
+        --output "$index" \
+        --exclude b__ \
+        --quiet 2>&1); then
+    record_fail "$name/index" "scip_ada index failed"
+    return
+  fi
+  record_pass "$name/index"
+
+  # --- Tier 1: Structural verifications ---
+  verify_metadata      "$name" "$index"
+  verify_no_empty_docs "$name" "$index"
+  verify_occurrence_ranges "$name" "$index"
+  verify_stats         "$name" "$index" 30 500 2000
+
+  # --- Tier 2: Content verifications ---
+  verify_symbols       "$name" "$index" \
+    "SPARKNaCl" "Sign" "Secretbox" "Cryptobox" "Scalar" "Hashing"
+  verify_doc_paths     "$name" "$index" \
+    "sparknacl.ads" "sparknacl-sign.ads" "sparknacl-secretbox.ads"
+  verify_symbols_have_info "$name" "$index"
+  # Keypair is a procedure (kind=17) for generating crypto key pairs
+  verify_symbol_kind      "$name" "$index" "Keypair" 17
+  # Hash is a procedure (kind=17) in hashing packages
+  verify_symbol_kind      "$name" "$index" "Hash" 17
+  verify_symbol_signature "$name" "$index" "Hash" "Hash"
+
+  # --- Tier 3: Integrity verifications ---
+  verify_xref_integrity   "$name" "$index"
+  verify_def_ref_balance  "$name" "$index"
+
+  rm -f "$index"
+}
+
 # ===========================================================================
 # MAIN
 # ===========================================================================
@@ -699,6 +834,8 @@ echo ""
 test_ada_toml
 test_ada_traits_containers
 test_pragmarc
+test_whitakers_words
+test_sparknacl
 
 echo ""
 echo "========================================"

--- a/tests/fixtures/ada2022/snapshot/src/ada2022_main.adb
+++ b/tests/fixtures/ada2022/snapshot/src/ada2022_main.adb
@@ -8,56 +8,62 @@
   --    - Image attribute on all types ('Image without prefix in Ada 2022)
   
   with Ada.Text_IO;   use Ada.Text_IO;
-//     ^^^ reference scip-ada . . . Ada/
-//         ^^^^^^^ reference scip-ada . . . Text_IO/
+//     ^^^ reference scip-ada . Ada2022 . Ada/
+//         ^^^^^^^ reference scip-ada . Ada2022 . Text_IO/
   with Ada2022_Types; use Ada2022_Types;
-//     ^^^^^^^^^^^^^ reference scip-ada . . . Ada2022_Types/
+//     ^^^^^^^^^^^^^ reference scip-ada . Ada2022 . Ada2022_Types/
   
   procedure Ada2022_Main is
-//          ^^^^^^^^^^^^ definition scip-ada . . . Ada2022_Main().
+//          ^^^^^^^^^^^^ definition scip-ada . Ada2022 . Ada2022_Main().
 //          kind Function
-//          documentation
-//          > procedure Ada2022_Main
-//          ^^^^^^^^^^^^ definition scip-ada . . . Ada2022_Main().
+//          ^^^^^^^^^^^^ definition scip-ada . Ada2022 . Ada2022_Main().
 //          kind Function
-//          documentation
-//          > procedure Ada2022_Main
   
      -----------------------------------------------------------------
      --  Delta aggregates
      -----------------------------------------------------------------
      Origin : constant Point := (X => 0, Y => 0);
-//   ^^^^^^ definition scip-ada . . . Origin#
+//   ^^^^^^ definition scip-ada . Ada2022 . Origin#
 //   kind Struct
-//                     ^^^^^ reference scip-ada . . . Point#
-//                               ^ reference scip-ada . . . X.
-//                                       ^ reference scip-ada . . . Y.
+//   documentation
+//   > --------------------------------------------------------------
+//   > Delta aggregates
+//   > --------------------------------------------------------------
+//                     ^^^^^ reference scip-ada . Ada2022 . Point#
+//                               ^ reference scip-ada . Ada2022 . X.
+//                                       ^ reference scip-ada . Ada2022 . Y.
   
      --  Record delta aggregate: modify one field
      P1 : Point := (Origin with delta X => 10);
-//   ^^ definition scip-ada . . . P1#
+//   ^^ definition scip-ada . Ada2022 . P1#
 //   kind Struct
-//                  ^^^^^^ reference scip-ada . . . Origin#
+//   documentation
+//   > Record delta aggregate: modify one field
+//                  ^^^^^^ reference scip-ada . Ada2022 . Origin#
   
      --  Chain delta: modify both fields
      P2 : constant Point := (P1 with delta Y => 20);
-//   ^^ definition scip-ada . . . P2#
+//   ^^ definition scip-ada . Ada2022 . P2#
 //   kind Struct
-//                           ^^ reference scip-ada . . . P1#
+//   documentation
+//   > Chain delta: modify both fields
+//                           ^^ reference scip-ada . Ada2022 . P1#
   
      --  Color delta aggregate
      Base_Color : constant Color := (R => 255, G => 128, B => 0, A => 255);
-//   ^^^^^^^^^^ definition scip-ada . . . Base_Color#
+//   ^^^^^^^^^^ definition scip-ada . Ada2022 . Base_Color#
 //   kind Struct
-//                         ^^^^^ reference scip-ada . . . Color#
-//                                   ^ reference scip-ada . . . R.
-//                                             ^ reference scip-ada . . . G.
-//                                                       ^ reference scip-ada . . . B.
-//                                                               ^ reference scip-ada . . . A.
+//   documentation
+//   > Color delta aggregate
+//                         ^^^^^ reference scip-ada . Ada2022 . Color#
+//                                   ^ reference scip-ada . Ada2022 . R.
+//                                             ^ reference scip-ada . Ada2022 . G.
+//                                                       ^ reference scip-ada . Ada2022 . B.
+//                                                               ^ reference scip-ada . Ada2022 . A.
      Faded      : constant Color := (Base_Color with delta A => 128);
-//   ^^^^^ definition scip-ada . . . Faded#
+//   ^^^^^ definition scip-ada . Ada2022 . Faded#
 //   kind Struct
-//                                   ^^^^^^^^^^ reference scip-ada . . . Base_Color#
+//                                   ^^^^^^^^^^ reference scip-ada . Ada2022 . Base_Color#
   
      -----------------------------------------------------------------
      --  Iterated component associations
@@ -65,201 +71,211 @@
   
      --  Array with iterated association: squares
      Squares : constant Fixed_Array := (for I in 1 .. 5 => I * I);
-//   ^^^^^^^ definition scip-ada . . . Squares.
+//   ^^^^^^^ definition scip-ada . Ada2022 . Squares.
 //   kind Variable
-//                      ^^^^^^^^^^^^^^^^^^^^ reference scip-ada . . . Fixed_Array(integer)#
-//                                          ^ definition scip-ada . . . I.
+//   documentation
+//   > Array with iterated association: squares
+//                      ^^^^^^^^^^^^^^^^^^^^ reference scip-ada . Ada2022 . `Fixed_Array(integer)`#
+//                                          ^ definition scip-ada . Ada2022 . I.
 //                                          kind Variable
-//                                                         ^ reference scip-ada . . . I.
-//                                                             ^ reference scip-ada . . . I.
+//                                          documentation
+//                                          > Array with iterated association: squares
+//                                                         ^ reference scip-ada . Ada2022 . I.
+//                                                             ^ reference scip-ada . Ada2022 . I.
   
      --  Array with expression
      Doubled : constant Fixed_Array := (for I in 1 .. 5 => I * 2);
-//   ^^^^^^^ definition scip-ada . . . Doubled.
+//   ^^^^^^^ definition scip-ada . Ada2022 . Doubled.
 //   kind Variable
-//                                                         ^ reference scip-ada . . . I.
+//   documentation
+//   > Array with expression
+//                                                         ^ reference scip-ada . Ada2022 . I.
   
      -----------------------------------------------------------------
      --  Target name symbol (@) in assignments
      -----------------------------------------------------------------
      Counter : Integer := 10;
-//   ^^^^^^^ definition scip-ada . . . Counter.
+//   ^^^^^^^ definition scip-ada . Ada2022 . Counter.
 //   kind Variable
+//   documentation
+//   > --------------------------------------------------------------
+//   > Target name symbol (@) in assignments
+//   > --------------------------------------------------------------
   
      -----------------------------------------------------------------
      --  Default_Initial_Condition (aspect on Positive_Int type)
      -----------------------------------------------------------------
      PI : Positive_Int := Make (42);
-//   ^^ definition scip-ada . . . PI#
+//   ^^ definition scip-ada . Ada2022 . PI#
 //   kind Struct
-//        ^^^^^^^^^^^^ reference scip-ada . . . Positive_Int#
-//                        ^^^^ reference scip-ada . . . Make().
+//   documentation
+//   > --------------------------------------------------------------
+//   > Default_Initial_Condition (aspect on Positive_Int type)
+//   > --------------------------------------------------------------
+//        ^^^^^^^^^^^^ reference scip-ada . Ada2022 . Positive_Int#
+//                        ^^^^ reference scip-ada . Ada2022 . Make().
   
      -----------------------------------------------------------------
      --  Declare expression
      -----------------------------------------------------------------
      function Triangle_Area (Base, Height : Float) return Float is
-//            ^^^^^^^^^^^^^ definition scip-ada . . . Triangle_Area().
+//            ^^^^^^^^^^^^^ definition scip-ada . Ada2022 . Triangle_Area().
 //            kind Function
-//            documentation
-//            > function Triangle_Area (Base, Height : Float) return Float
-//            ^^^^^^^^^^^^^ definition scip-ada . . . Triangle_Area().
+//            ^^^^^^^^^^^^^ definition scip-ada . Ada2022 . Triangle_Area().
 //            kind Function
-//            documentation
-//            > function Triangle_Area (Base, Height : Float) return Float
-//                           ^^^^ definition scip-ada . . . Base.
+//                           ^^^^ definition scip-ada . Ada2022 . Base.
 //                           kind Variable
-//                           documentation
-//                           > function Triangle_Area (Base, Height : Float) return Float
-//                                 ^^^^^^ definition scip-ada . . . Height.
+//                                 ^^^^^^ definition scip-ada . Ada2022 . Height.
 //                                 kind Variable
-//                                 documentation
-//                                 > function Triangle_Area (Base, Height : Float) return Float
        (declare
           Half : constant Float := Base / 2.0;
-//        ^^^^ definition scip-ada . . . Half.
+//        ^^^^ definition scip-ada . Ada2022 . Half.
 //        kind Variable
-//                                 ^^^^ reference scip-ada . . . Base.
+//                                 ^^^^ reference scip-ada . Ada2022 . Base.
         begin
           Half * Height);
-//        ^^^^ reference scip-ada . . . Half.
-//               ^^^^^^ reference scip-ada . . . Height.
+//        ^^^^ reference scip-ada . Ada2022 . Half.
+//               ^^^^^^ reference scip-ada . Ada2022 . Height.
   
      -----------------------------------------------------------------
      --  Local subprogram using Ada 2022 features
      -----------------------------------------------------------------
      procedure Show_Point (Label : String; P : Point) is
-//             ^^^^^^^^^^ definition scip-ada . . . Show_Point().
+//             ^^^^^^^^^^ definition scip-ada . Ada2022 . Show_Point().
 //             kind Function
 //             documentation
-//             > procedure Show_Point (Label : String; P : Point)
-//             ^^^^^^^^^^ definition scip-ada . . . Show_Point().
+//             > --------------------------------------------------------------
+//             > Local subprogram using Ada 2022 features
+//             > --------------------------------------------------------------
+//             ^^^^^^^^^^ definition scip-ada . Ada2022 . Show_Point().
 //             kind Function
 //             documentation
-//             > procedure Show_Point (Label : String; P : Point)
-//                         ^^^^^ definition scip-ada . . . Label.
+//             > --------------------------------------------------------------
+//             > Local subprogram using Ada 2022 features
+//             > --------------------------------------------------------------
+//                         ^^^^^ definition scip-ada . Ada2022 . Label.
 //                         kind Variable
 //                         documentation
-//                         > procedure Show_Point (Label : String; P : Point)
-//                                         ^ definition scip-ada . . . P#
+//                         > --------------------------------------------------------------
+//                         > Local subprogram using Ada 2022 features
+//                         > --------------------------------------------------------------
+//                                         ^ definition scip-ada . Ada2022 . P#
 //                                         kind Struct
 //                                         documentation
-//                                         > procedure Show_Point (Label : String; P : Point)
+//                                         > --------------------------------------------------------------
+//                                         > Local subprogram using Ada 2022 features
+//                                         > --------------------------------------------------------------
      begin
         Put_Line (Label & ": (" & P.X'Image & "," & P.Y'Image & ")");
-//      ^^^^^^^^ reference scip-ada . . . Put_Line().
-//                ^^^^^ reference scip-ada . . . Label.
-//                                ^ reference scip-ada . . . P#
-//                                                  ^ reference scip-ada . . . P#
+//      ^^^^^^^^ reference scip-ada . Ada2022 . Put_Line().
+//                ^^^^^ reference scip-ada . Ada2022 . Label.
+//                                ^ reference scip-ada . Ada2022 . P#
+//                                                  ^ reference scip-ada . Ada2022 . P#
      end Show_Point;
-//       ^^^^^^^^^^ reference scip-ada . . . Show_Point().
-//                 ^^^^^^^^^^ reference scip-ada . . . Show_Point().
+//       ^^^^^^^^^^ reference scip-ada . Ada2022 . Show_Point().
+//                 ^^^^^^^^^^ reference scip-ada . Ada2022 . Show_Point().
   
      procedure Show_Array (Label : String; A : Fixed_Array) is
-//             ^^^^^^^^^^ definition scip-ada . . . Show_Array().
+//             ^^^^^^^^^^ definition scip-ada . Ada2022 . Show_Array().
 //             kind Function
-//             documentation
-//             > procedure Show_Array (Label : String; A : Fixed_Array)
-//             ^^^^^^^^^^ definition scip-ada . . . Show_Array().
+//             ^^^^^^^^^^ definition scip-ada . Ada2022 . Show_Array().
 //             kind Function
-//             documentation
-//             > procedure Show_Array (Label : String; A : Fixed_Array)
-//                                         ^ definition scip-ada . . . A.
+//                                         ^ definition scip-ada . Ada2022 . A.
 //                                         kind Variable
-//                                         documentation
-//                                         > procedure Show_Array (Label : String; A : Fixed_Array)
      begin
         Put (Label & ": [");
-//      ^^^ reference scip-ada . . . Put().
-//           ^^^^^ reference scip-ada . . . Label.
+//      ^^^ reference scip-ada . Ada2022 . Put().
+//           ^^^^^ reference scip-ada . Ada2022 . Label.
         for I in A'Range loop
-//               ^ reference scip-ada . . . A.
+//               ^ reference scip-ada . Ada2022 . A.
            Put (A (I)'Image);
-//              ^ reference scip-ada . . . A.
-//                 ^ reference scip-ada . . . I.
+//              ^ reference scip-ada . Ada2022 . A.
+//                 ^ reference scip-ada . Ada2022 . I.
            if I < A'Last then
-//            ^ reference scip-ada . . . I.
-//                ^ reference scip-ada . . . A.
+//            ^ reference scip-ada . Ada2022 . I.
+//                ^ reference scip-ada . Ada2022 . A.
               Put (",");
            end if;
         end loop;
         Put_Line ("]");
      end Show_Array;
-//       ^^^^^^^^^^ reference scip-ada . . . Show_Array().
-//                 ^^^^^^^^^^ reference scip-ada . . . Show_Array().
+//       ^^^^^^^^^^ reference scip-ada . Ada2022 . Show_Array().
+//                 ^^^^^^^^^^ reference scip-ada . Ada2022 . Show_Array().
   
      --  More locals for testing
      Area_Val : Float;
-//   ^^^^^^^^ definition scip-ada . . . Area_Val.
+//   ^^^^^^^^ definition scip-ada . Ada2022 . Area_Val.
 //   kind Variable
+//   documentation
+//   > More locals for testing
   
   begin
      -----------------------------------------------------------------
      --  Show delta aggregate results
      -----------------------------------------------------------------
      Show_Point ("Origin", Origin);
-//   ^^^^^^^^^^ reference scip-ada . . . Show_Point().
-//                         ^^^^^^ reference scip-ada . . . Origin#
+//   ^^^^^^^^^^ reference scip-ada . Ada2022 . Show_Point().
+//                         ^^^^^^ reference scip-ada . Ada2022 . Origin#
      Show_Point ("P1 (delta X)", P1);
-//   ^^^^^^^^^^ reference scip-ada . . . Show_Point().
-//                               ^^ reference scip-ada . . . P1#
+//   ^^^^^^^^^^ reference scip-ada . Ada2022 . Show_Point().
+//                               ^^ reference scip-ada . Ada2022 . P1#
      Show_Point ("P2 (delta Y)", P2);
-//   ^^^^^^^^^^ reference scip-ada . . . Show_Point().
-//                               ^^ reference scip-ada . . . P2#
+//   ^^^^^^^^^^ reference scip-ada . Ada2022 . Show_Point().
+//                               ^^ reference scip-ada . Ada2022 . P2#
   
      Put_Line ("Faded alpha: " & Faded.A'Image);
-//                               ^^^^^ reference scip-ada . . . Faded#
+//                               ^^^^^ reference scip-ada . Ada2022 . Faded#
   
      -----------------------------------------------------------------
      --  Show iterated component associations
      -----------------------------------------------------------------
      Show_Array ("Squares", Squares);
-//   ^^^^^^^^^^ reference scip-ada . . . Show_Array().
-//                          ^^^^^^^ reference scip-ada . . . Squares.
+//   ^^^^^^^^^^ reference scip-ada . Ada2022 . Show_Array().
+//                          ^^^^^^^ reference scip-ada . Ada2022 . Squares.
      Show_Array ("Doubled", Doubled);
-//   ^^^^^^^^^^ reference scip-ada . . . Show_Array().
-//                          ^^^^^^^ reference scip-ada . . . Doubled.
+//   ^^^^^^^^^^ reference scip-ada . Ada2022 . Show_Array().
+//                          ^^^^^^^ reference scip-ada . Ada2022 . Doubled.
   
      -----------------------------------------------------------------
      --  Target name (@) — increment Counter using @
      -----------------------------------------------------------------
      Counter := @ + 5;
-//   ^^^^^^^ reference scip-ada . . . Counter.
+//   ^^^^^^^ reference scip-ada . Ada2022 . Counter.
      Put_Line ("Counter after @+5: " & Counter'Image);
-//                                     ^^^^^^^ reference scip-ada . . . Counter.
+//                                     ^^^^^^^ reference scip-ada . Ada2022 . Counter.
   
      Counter := @ * 2;
-//   ^^^^^^^ reference scip-ada . . . Counter.
+//   ^^^^^^^ reference scip-ada . Ada2022 . Counter.
      Put_Line ("Counter after @*2: " & Counter'Image);
-//                                     ^^^^^^^ reference scip-ada . . . Counter.
+//                                     ^^^^^^^ reference scip-ada . Ada2022 . Counter.
   
      -----------------------------------------------------------------
      --  Declare expression
      -----------------------------------------------------------------
      Area_Val := Triangle_Area (10.0, 5.0);
-//   ^^^^^^^^ reference scip-ada . . . Area_Val.
-//               ^^^^^^^^^^^^^ reference scip-ada . . . Triangle_Area().
+//   ^^^^^^^^ reference scip-ada . Ada2022 . Area_Val.
+//               ^^^^^^^^^^^^^ reference scip-ada . Ada2022 . Triangle_Area().
      Put_Line ("Triangle area: " & Area_Val'Image);
-//                                 ^^^^^^^^ reference scip-ada . . . Area_Val.
+//                                 ^^^^^^^^ reference scip-ada . Ada2022 . Area_Val.
   
      -----------------------------------------------------------------
      --  Default_Initial_Condition — use the validated type
      -----------------------------------------------------------------
      Put_Line ("Positive_Int value: " & Get (PI)'Image);
-//                                      ^^^ reference scip-ada . . . Get().
-//                                           ^^ reference scip-ada . . . PI#
+//                                      ^^^ reference scip-ada . Ada2022 . Get().
+//                                           ^^ reference scip-ada . Ada2022 . PI#
      PI := Make (99);
-//   ^^ reference scip-ada . . . PI#
+//   ^^ reference scip-ada . Ada2022 . PI#
      Put_Line ("Updated value: " & Get (PI)'Image);
-//                                      ^^ reference scip-ada . . . PI#
+//                                      ^^ reference scip-ada . Ada2022 . PI#
   
      -----------------------------------------------------------------
      --  Ada 2022 'Image on non-scalar prefix (if supported)
      -----------------------------------------------------------------
      Put_Line ("Direction: " & North'Image);
-//                             ^^^^^ reference scip-ada . . . North.
+//                             ^^^^^ reference scip-ada . Ada2022 . North.
   
   end Ada2022_Main;
-//    ^^^^^^^^^^^^ reference scip-ada . . . Ada2022_Main().
-//                ^^^^^^^^^^^^ reference scip-ada . . . Ada2022_Main().
+//    ^^^^^^^^^^^^ reference scip-ada . Ada2022 . Ada2022_Main().
+//                ^^^^^^^^^^^^ reference scip-ada . Ada2022 . Ada2022_Main().
   

--- a/tests/fixtures/ada2022/snapshot/src/ada2022_types.adb
+++ b/tests/fixtures/ada2022/snapshot/src/ada2022_types.adb
@@ -1,45 +1,45 @@
   package body Ada2022_Types is
-//             ^^^^^^^^^^^^^ definition scip-ada . . . Ada2022_Types/
+//             ^^^^^^^^^^^^^ definition scip-ada . Ada2022 . Ada2022_Types/
   
      function Is_Valid (Value : Positive_Int) return Boolean is
-//            ^^^^^^^^ definition scip-ada . . . Is_Valid().
-//                      ^^^^^ definition scip-ada . . . Value#
-//                              ^^^^^^^^^^^^ reference scip-ada . . . Positive_Int#
+//            ^^^^^^^^ definition scip-ada . Ada2022 . Is_Valid().
+//                      ^^^^^ definition scip-ada . Ada2022 . Value#
+//                              ^^^^^^^^^^^^ reference scip-ada . Ada2022 . Positive_Int#
      begin
         return Value.Value > 0;
-//                   ^^^^^ reference scip-ada . . . Value.
+//                   ^^^^^ reference scip-ada . Ada2022 . Value.
      end Is_Valid;
   
      function Make (V : Positive) return Positive_Int is
-//            ^^^^ definition scip-ada . . . Make().
-//                  ^ definition scip-ada . . . V.
+//            ^^^^ definition scip-ada . Ada2022 . Make().
+//                  ^ definition scip-ada . Ada2022 . V.
      begin
         return (Value => V);
      end Make;
   
      function Get (Value : Positive_Int) return Positive is
-//            ^^^ definition scip-ada . . . Get().
-//                 ^^^^^ definition scip-ada . . . Value#
+//            ^^^ definition scip-ada . Ada2022 . Get().
+//                 ^^^^^ definition scip-ada . Ada2022 . Value#
      begin
         return Value.Value;
      end Get;
   
      function Area (S : Shape) return Float is
-//            ^^^^ definition scip-ada . . . Area().
-//                  ^ definition scip-ada . . . S#
-//                      ^^^^^ reference scip-ada . . . Shape#
+//            ^^^^ definition scip-ada . Ada2022 . Area().
+//                  ^ definition scip-ada . Ada2022 . S#
+//                      ^^^^^ reference scip-ada . Ada2022 . Shape#
         pragma Unreferenced (S);
      begin
         return 0.0;
      end Area;
   
      function Area (S : Circle) return Float is
-//            ^^^^ definition scip-ada . . . Area().
-//                  ^ definition scip-ada . . . S#
-//                      ^^^^^^ reference scip-ada . . . Circle#
+//            ^^^^ definition scip-ada . Ada2022 . Area().
+//                  ^ definition scip-ada . Ada2022 . S#
+//                      ^^^^^^ reference scip-ada . Ada2022 . Circle#
      begin
         return 3.14159 * S.Radius * S.Radius;
-//                         ^^^^^^ reference scip-ada . . . Radius.
+//                         ^^^^^^ reference scip-ada . Ada2022 . Radius.
      end Area;
   
   end Ada2022_Types;

--- a/tests/fixtures/ada2022/snapshot/src/ada2022_types.ads
+++ b/tests/fixtures/ada2022/snapshot/src/ada2022_types.ads
@@ -1,181 +1,192 @@
   --  Ada 2022 Types — types and contracts for Ada 2022 feature testing
   
   package Ada2022_Types is
-//        ^^^^^^^^^^^^^ definition scip-ada . . . Ada2022_Types/
+//        ^^^^^^^^^^^^^ definition scip-ada . Ada2022 . Ada2022_Types/
 //        kind Namespace
   
      --  Basic record type for delta aggregates
-//             ^^^^^ reference scip-ada . . . Value#
+//             ^^^^^ reference scip-ada . Ada2022 . Value#
      type Point is record
-//       ^^^^^^^^ reference scip-ada . . . Is_Valid().
-//        ^^^^^ definition scip-ada . . . Point#
+//       ^^^^^^^^ reference scip-ada . Ada2022 . Is_Valid().
+//        ^^^^^ definition scip-ada . Ada2022 . Point#
 //        kind Class
-//               ^^^^^^^^ reference scip-ada . . . Is_Valid().
+//        documentation
+//        > Basic record type for delta aggregates
+//               ^^^^^^^^ reference scip-ada . Ada2022 . Is_Valid().
         X : Integer := 0;
-//      ^ definition scip-ada . . . X.
+//      ^ definition scip-ada . Ada2022 . X.
 //      kind Variable
         Y : Integer := 0;
-//      ^ definition scip-ada . . . Y.
+//      ^ definition scip-ada . Ada2022 . Y.
 //      kind Variable
-//                                       ^^^^^^^^^^^^ reference scip-ada . . . Positive_Int#
+//                                       ^^^^^^^^^^^^ reference scip-ada . Ada2022 . Positive_Int#
      end record;
-//             ^^^^^ reference scip-ada . . . Point#
+//             ^^^^^ reference scip-ada . Ada2022 . Point#
   
-//              ^^^^^ reference scip-ada . . . Value.
-//                       ^ reference scip-ada . . . V.
+//              ^^^^^ reference scip-ada . Ada2022 . Value.
+//                       ^ reference scip-ada . Ada2022 . V.
      --  Record with more fields for aggregate testing
-//       ^^^^ reference scip-ada . . . Make().
-//           ^^^^ reference scip-ada . . . Make().
-//                        ^^^^^^^^^^^^^ reference scip-ada . . . Ada2022_Types/
+//       ^^^^ reference scip-ada . Ada2022 . Make().
+//           ^^^^ reference scip-ada . Ada2022 . Make().
+//                        ^^^^^^^^^^^^^ reference scip-ada . Ada2022 . Ada2022_Types/
      type Color is record
-//        ^^^^^ definition scip-ada . . . Color#
+//        ^^^^^ definition scip-ada . Ada2022 . Color#
 //        kind Class
+//        documentation
+//        > Record with more fields for aggregate testing
         R : Integer := 0;
-//      ^ definition scip-ada . . . R.
+//      ^ definition scip-ada . Ada2022 . R.
 //      kind Variable
-//                         ^^^^^^^^^^^^ reference scip-ada . . . Positive_Int#
+//                         ^^^^^^^^^^^^ reference scip-ada . Ada2022 . Positive_Int#
         G : Integer := 0;
-//      ^ definition scip-ada . . . G.
+//      ^ definition scip-ada . Ada2022 . G.
 //      kind Variable
         B : Integer := 0;
-//      ^ definition scip-ada . . . B.
+//      ^ definition scip-ada . Ada2022 . B.
 //      kind Variable
-//             ^^^^^ reference scip-ada . . . Value#
-//                   ^^^^^ reference scip-ada . . . Value.
+//             ^^^^^ reference scip-ada . Ada2022 . Value#
+//                   ^^^^^ reference scip-ada . Ada2022 . Value.
         A : Integer := 255;
-//      ^ definition scip-ada . . . A.
+//      ^ definition scip-ada . Ada2022 . A.
 //      kind Variable
-//       ^^^ reference scip-ada . . . Get().
-//          ^^^ reference scip-ada . . . Get().
+//       ^^^ reference scip-ada . Ada2022 . Get().
+//          ^^^ reference scip-ada . Ada2022 . Get().
      end record;
-//             ^^^^^ reference scip-ada . . . Color#
+//             ^^^^^ reference scip-ada . Ada2022 . Color#
   
      --  Array types for iterated component associations
-//                           ^ reference scip-ada . . . S#
+//                           ^ reference scip-ada . Ada2022 . S#
      type Int_Array is array (Positive range <>) of Integer;
-//        ^^^^^^^^^^^^^^^^^^ definition scip-ada . . . Int_Array(integer)#
+//        ^^^^^^^^^^^^^^^^^^ definition scip-ada . Ada2022 . `Int_Array(integer)`#
 //        kind Type
+//        documentation
+//        > Array types for iterated component associations
      type Fixed_Array is array (1 .. 5) of Integer;
-//        ^^^^^ reference scip-ada . . . Point#
-//        ^^^^^^^^^^^^^^^^^^^^ definition scip-ada . . . Fixed_Array(integer)#
+//        ^^^^^ reference scip-ada . Ada2022 . Point#
+//        ^^^^^^^^^^^^^^^^^^^^ definition scip-ada . Ada2022 . `Fixed_Array(integer)`#
 //        kind Type
      type Matrix is array (1 .. 3, 1 .. 3) of Integer;
-//       ^^^^ reference scip-ada . . . Area().
-//        ^^^^^^^^^^^^^^^ definition scip-ada . . . Matrix(integer)#
+//       ^^^^ reference scip-ada . Ada2022 . Area().
+//        ^^^^^^^^^^^^^^^ definition scip-ada . Ada2022 . `Matrix(integer)`#
 //        kind Type
-//           ^^^^ reference scip-ada . . . Area().
+//           ^^^^ reference scip-ada . Ada2022 . Area().
   
      --  Type with Default_Initial_Condition (Ada 2022 contract aspect)
-//                 ^^^^^ reference scip-ada . . . Point#
+//                 ^^^^^ reference scip-ada . Ada2022 . Point#
      type Positive_Int is private
-//        ^^^^^^^^^^^^ definition scip-ada . . . Positive_Int#
+//        ^^^^^^^^^^^^ definition scip-ada . Ada2022 . Positive_Int#
 //        kind Class
+//        documentation
+//        > Type with Default_Initial_Condition (Ada 2022 contract aspect)
        with Default_Initial_Condition => Is_Valid (Positive_Int);
-//                       ^ reference scip-ada . . . S#
-//                                  ^ reference scip-ada . . . S#
-//                                    ^^^^^^ reference scip-ada . . . Radius.
-//                                       ^^^^^^^^ reference scip-ada . . . Is_Valid().
+//                       ^ reference scip-ada . Ada2022 . S#
+//                                  ^ reference scip-ada . Ada2022 . S#
+//                                    ^^^^^^ reference scip-ada . Ada2022 . Radius.
+//                                       ^^^^^^^^ reference scip-ada . Ada2022 . Is_Valid().
   
-//       ^^^^ reference scip-ada . . . Area().
-//           ^^^^ reference scip-ada . . . Area().
+//       ^^^^ reference scip-ada . Ada2022 . Area().
+//           ^^^^ reference scip-ada . Ada2022 . Area().
      function Is_Valid (Value : Positive_Int) return Boolean;
-//            ^^^^^^^^ definition scip-ada . . . Is_Valid().
+//            ^^^^^^^^ definition scip-ada . Ada2022 . Is_Valid().
 //            kind Function
-//            documentation
-//            > function Is_Valid (Value : Positive_Int) return Boolean
-//                      ^^^^^ definition scip-ada . . . Value#
+//                      ^^^^^ definition scip-ada . Ada2022 . Value#
 //                      kind Struct
-//                      documentation
-//                      > function Is_Valid (Value : Positive_Int) return Boolean
-//                         ^^^^^ reference scip-ada . . . Color#
-//                              ^^^^^^^^^^^^ reference scip-ada . . . Positive_Int#
+//                         ^^^^^ reference scip-ada . Ada2022 . Color#
+//                              ^^^^^^^^^^^^ reference scip-ada . Ada2022 . Positive_Int#
      function Make (V : Positive) return Positive_Int;
-//    ^^^^^^^^^^^^^ reference scip-ada . . . Ada2022_Types/
-//            ^^^^ definition scip-ada . . . Make().
+//    ^^^^^^^^^^^^^ reference scip-ada . Ada2022 . Ada2022_Types/
+//            ^^^^ definition scip-ada . Ada2022 . Make().
 //            kind Function
-//            documentation
-//            > function Make (V : Positive) return Positive_Int
-//                 ^^^^^^^^^^^^^ reference scip-ada . . . Ada2022_Types/
-//                  ^ definition scip-ada . . . V.
+//                 ^^^^^^^^^^^^^ reference scip-ada . Ada2022 . Ada2022_Types/
+//                  ^ definition scip-ada . Ada2022 . V.
 //                  kind Variable
-//                  documentation
-//                  > function Make (V : Positive) return Positive_Int
-//                                       ^^^^^^^^^^^^ reference scip-ada . . . Positive_Int#
+//                                       ^^^^^^^^^^^^ reference scip-ada . Ada2022 . Positive_Int#
      function Get (Value : Positive_Int) return Positive;
-//            ^^^ definition scip-ada . . . Get().
+//            ^^^ definition scip-ada . Ada2022 . Get().
 //            kind Function
-//            documentation
-//            > function Get (Value : Positive_Int) return Positive
-//                         ^^^^^^^^^^^^ reference scip-ada . . . Positive_Int#
+//                         ^^^^^^^^^^^^ reference scip-ada . Ada2022 . Positive_Int#
   
      --  Tagged type for class-wide / extension testing
      type Shape is tagged record
-//        ^^^^^ definition scip-ada . . . Shape#
+//        ^^^^^ definition scip-ada . Ada2022 . Shape#
 //        kind Class
+//        documentation
+//        > Tagged type for class-wide / extension testing
         Name : String (1 .. 10) := (others => ' ');
-//      ^^^^ definition scip-ada . . . Name.
+//      ^^^^ definition scip-ada . Ada2022 . Name.
 //      kind Variable
      end record;
-//             ^^^^^ reference scip-ada . . . Shape#
+//             ^^^^^ reference scip-ada . Ada2022 . Shape#
   
      function Area (S : Shape) return Float;
-//            ^^^^ definition scip-ada . . . Area().
+//            ^^^^ definition scip-ada . Ada2022 . Area().
 //            kind Function
-//            documentation
-//            > function Area (S : Shape) return Float
-//            ^^^^^ reference scip-ada . . . Shape#
-//                  ^ definition scip-ada . . . S#
+//            ^^^^^ reference scip-ada . Ada2022 . Shape#
+//                  ^ definition scip-ada . Ada2022 . S#
 //                  kind Struct
-//                  documentation
-//                  > function Area (S : Shape) return Float
-//                      ^^^^^ reference scip-ada . . . Shape#
+//                      ^^^^^ reference scip-ada . Ada2022 . Shape#
   
-//                      ^^^^^^^^^^^^^^^^^^^^ reference scip-ada . . . Fixed_Array(integer)#
+//                      ^^^^^^^^^^^^^^^^^^^^ reference scip-ada . Ada2022 . `Fixed_Array(integer)`#
      type Circle is new Shape with record
-//        ^^^^^^ definition scip-ada . . . Circle#
+//        ^^^^^^ definition scip-ada . Ada2022 . Circle#
 //        kind Class
-//                      ^^^^^ reference scip-ada . . . Shape#
+//        relationship scip-ada . Ada2022 . Ada2022_Types#Shape# type_definition
+//                      ^^^^^ reference scip-ada . Ada2022 . Shape#
         Radius : Float := 0.0;
-//      ^^^^^^ definition scip-ada . . . Radius.
+//      ^^^^^^ definition scip-ada . Ada2022 . Radius.
 //      kind Variable
      end record;
-//             ^^^^^^ reference scip-ada . . . Circle#
+//             ^^^^^^ reference scip-ada . Ada2022 . Circle#
   
      overriding function Area (S : Circle) return Float;
-//                       ^^^^^^ reference scip-ada . . . Circle#
-//                                 ^^^^^^ reference scip-ada . . . Circle#
+//                       ^^^^^^ reference scip-ada . Ada2022 . Circle#
+//                                 ^^^^^^ reference scip-ada . Ada2022 . Circle#
   
      --  Enumeration for various tests
      type Direction is (North, South, East, West);
-//        ^^^^^^^^^ definition scip-ada . . . Direction#
+//        ^^^^^^^^^ definition scip-ada . Ada2022 . Direction#
 //        kind Enum
-//                      ^^^^^ definition scip-ada . . . North.
+//        documentation
+//        > Enumeration for various tests
+//                      ^^^^^ definition scip-ada . Ada2022 . North.
 //                      kind EnumMember
-//                             ^^^^^ definition scip-ada . . . South.
+//                      documentation
+//                      > Enumeration for various tests
+//                             ^^^^^ definition scip-ada . Ada2022 . South.
 //                             kind EnumMember
-//                                    ^^^^ definition scip-ada . . . East.
+//                             documentation
+//                             > Enumeration for various tests
+//                                    ^^^^ definition scip-ada . Ada2022 . East.
 //                                    kind EnumMember
-//                                          ^^^^ definition scip-ada . . . West.
+//                                    documentation
+//                                    > Enumeration for various tests
+//                                          ^^^^ definition scip-ada . Ada2022 . West.
 //                                          kind EnumMember
-//                                               ^^^^^^^^^ reference scip-ada . . . Direction#
+//                                          documentation
+//                                          > Enumeration for various tests
+//                                               ^^^^^^^^^ reference scip-ada . Ada2022 . Direction#
   
      --  Access type
      type Int_Access is access all Integer;
-//        ^^^^^^^^^^^^^^^^^^^ definition scip-ada . . . Int_Access(integer)#
+//        ^^^^^^^^^^^^^^^^^^^ definition scip-ada . Ada2022 . `Int_Access(integer)`#
 //        kind Type
+//        documentation
+//        > Access type
   
   private
      type Positive_Int is record
-//        ^^^^^^^^^^^^ definition scip-ada . . . Positive_Int#
+//        ^^^^^^^^^^^^ definition scip-ada . Ada2022 . Positive_Int#
 //        kind Class
-//        ^^^^^^^^^^^^^ reference scip-ada . . . Ada2022_Types/
+//        documentation
+//        > Type with Default_Initial_Condition (Ada 2022 contract aspect)
+//        ^^^^^^^^^^^^^ reference scip-ada . Ada2022 . Ada2022_Types/
         Value : Positive := 1;
-//      ^^^^^ definition scip-ada . . . Value.
+//      ^^^^^ definition scip-ada . Ada2022 . Value.
 //      kind Variable
      end record;
-//             ^^^^^^^^^^^^ reference scip-ada . . . Positive_Int#
+//             ^^^^^^^^^^^^ reference scip-ada . Ada2022 . Positive_Int#
   
   end Ada2022_Types;
-//    ^^^^^^^^^^^^^ reference scip-ada . . . Ada2022_Types/
-//                 ^^^^^^^^^^^^^ reference scip-ada . . . Ada2022_Types/
+//    ^^^^^^^^^^^^^ reference scip-ada . Ada2022 . Ada2022_Types/
+//                 ^^^^^^^^^^^^^ reference scip-ada . Ada2022 . Ada2022_Types/
   

--- a/tests/fixtures/generics/snapshot/src/generic_stack.adb
+++ b/tests/fixtures/generics/snapshot/src/generic_stack.adb
@@ -1,40 +1,40 @@
   package body Generic_Stack is
-//             ^^^^^^^^^^^^^ definition scip-ada . . . Generic_Stack/
+//             ^^^^^^^^^^^^^ definition scip-ada . Generics . Generic_Stack/
      procedure Push (S : in out Stack; Item : Element_Type) is
-//             ^^^^ definition scip-ada . . . Push().
-//                   ^ definition scip-ada . . . S#
-//                              ^^^^^ reference scip-ada . . . Stack#
-//                                     ^^^^ definition scip-ada . . . [Item]
-//                                            ^^^^^^^^^^^^ reference scip-ada . . . [Element_Type]
+//             ^^^^ definition scip-ada . Generics . Push().
+//                   ^ definition scip-ada . Generics . S#
+//                              ^^^^^ reference scip-ada . Generics . Stack#
+//                                     ^^^^ definition scip-ada . Generics . [Item]
+//                                            ^^^^^^^^^^^^ reference scip-ada . Generics . [Element_Type]
      begin
         if S.Top < Max_Size then
-//           ^^^ reference scip-ada . . . Top.
-//                 ^^^^^^^^ reference scip-ada . . . Max_Size.
+//           ^^^ reference scip-ada . Generics . Top.
+//                 ^^^^^^^^ reference scip-ada . Generics . Max_Size.
            S.Top := S.Top + 1;
            S.Data (S.Top) := Item;
-//           ^^^^ reference scip-ada . . . Data.
+//           ^^^^ reference scip-ada . Generics . Data.
         end if;
      end Push;
   
      procedure Pop (S : in out Stack; Item : out Element_Type) is
-//             ^^^ definition scip-ada . . . Pop().
-//                  ^ definition scip-ada . . . S#
-//                                    ^^^^ definition scip-ada . . . [Item]
+//             ^^^ definition scip-ada . Generics . Pop().
+//                  ^ definition scip-ada . Generics . S#
+//                                    ^^^^ definition scip-ada . Generics . [Item]
      begin
         Item := S.Data (S.Top);
         S.Top := S.Top - 1;
      end Pop;
   
      function Is_Empty (S : Stack) return Boolean is
-//            ^^^^^^^^ definition scip-ada . . . Is_Empty().
-//                      ^ definition scip-ada . . . S#
+//            ^^^^^^^^ definition scip-ada . Generics . Is_Empty().
+//                      ^ definition scip-ada . Generics . S#
      begin
         return S.Top = 0;
      end Is_Empty;
   
      function Size (S : Stack) return Natural is
-//            ^^^^ definition scip-ada . . . Size().
-//                  ^ definition scip-ada . . . S#
+//            ^^^^ definition scip-ada . Generics . Size().
+//                  ^ definition scip-ada . Generics . S#
      begin
         return S.Top;
      end Size;

--- a/tests/fixtures/generics/snapshot/src/generic_stack.ads
+++ b/tests/fixtures/generics/snapshot/src/generic_stack.ads
@@ -1,111 +1,99 @@
   generic
      type Element_Type is private;
-//        ^^^^^^^^^^^^ definition scip-ada . . . [Element_Type]
+//        ^^^^^^^^^^^^ definition scip-ada . Generics . [Element_Type]
 //        kind TypeParameter
-//        ^^^^^^^^^^^^^ reference scip-ada . . . Generic_Stack/
+//        ^^^^^^^^^^^^^ reference scip-ada . Generics . Generic_Stack/
      Max_Size : Positive;
-//   ^^^^^^^^ definition scip-ada . . . Max_Size.
+//   ^^^^^^^^ definition scip-ada . Generics . Max_Size.
 //   kind Variable
-//   ^^^^^^^^^^^^^ reference scip-ada . . . Generic_Stack/
+//   ^^^^^^^^^^^^^ reference scip-ada . Generics . Generic_Stack/
   package Generic_Stack is
-//        ^^^^^^^^^^^^^ definition scip-ada . . . Generic_Stack/
+//        ^^^^^^^^^^^^^ definition scip-ada . Generics . Generic_Stack/
 //        kind Namespace
-//         ^ reference scip-ada . . . S#
+//         ^ reference scip-ada . Generics . S#
      type Stack is private;
-//        ^^^^^ definition scip-ada . . . Stack#
+//        ^^^^^ definition scip-ada . Generics . Stack#
 //        kind Class
-//         ^ reference scip-ada . . . S#
-//           ^^^ reference scip-ada . . . Top.
-//                  ^ reference scip-ada . . . S#
-//                    ^^^ reference scip-ada . . . Top.
-//                            ^^^^^^^^^^^^^ reference scip-ada . . . Generic_Stack/
+//         ^ reference scip-ada . Generics . S#
+//           ^^^ reference scip-ada . Generics . Top.
+//                  ^ reference scip-ada . Generics . S#
+//                    ^^^ reference scip-ada . Generics . Top.
+//                            ^^^^^^^^^^^^^ reference scip-ada . Generics . Generic_Stack/
   
-//         ^ reference scip-ada . . . S#
-//                 ^ reference scip-ada . . . S#
-//                   ^^^ reference scip-ada . . . Top.
-//                           ^^^^ reference scip-ada . . . [Item]
+//         ^ reference scip-ada . Generics . S#
+//                 ^ reference scip-ada . Generics . S#
+//                   ^^^ reference scip-ada . Generics . Top.
+//                           ^^^^ reference scip-ada . Generics . [Item]
      procedure Push (S : in out Stack; Item : Element_Type);
-//             ^^^^ definition scip-ada . . . Push().
+//             ^^^^ definition scip-ada . Generics . Push().
 //             kind Function
-//             documentation
-//             > procedure Push (S : in out Stack; Item : Element_Type)
-//                   ^ definition scip-ada . . . S#
+//                   ^ definition scip-ada . Generics . S#
 //                   kind Struct
-//                   documentation
-//                   > procedure Push (S : in out Stack; Item : Element_Type)
-//                              ^^^^^ reference scip-ada . . . Stack#
-//                                     ^^^^ definition scip-ada . . . [Item]
+//                              ^^^^^ reference scip-ada . Generics . Stack#
+//                                     ^^^^ definition scip-ada . Generics . [Item]
 //                                     kind TypeParameter
-//                                     documentation
-//                                     > procedure Push (S : in out Stack; Item : Element_Type)
-//                                            ^^^^^^^^^^^^ reference scip-ada . . . [Element_Type]
+//                                            ^^^^^^^^^^^^ reference scip-ada . Generics . [Element_Type]
      procedure Pop (S : in out Stack; Item : out Element_Type);
-//       ^^^^ reference scip-ada . . . Push().
-//           ^^^^ reference scip-ada . . . Push().
-//             ^^^ definition scip-ada . . . Pop().
+//       ^^^^ reference scip-ada . Generics . Push().
+//           ^^^^ reference scip-ada . Generics . Push().
+//             ^^^ definition scip-ada . Generics . Pop().
 //             kind Function
-//             documentation
-//             > procedure Pop (S : in out Stack; Item : out Element_Type)
-//                             ^^^^^ reference scip-ada . . . Stack#
-//                                               ^^^^^^^^^^^^ reference scip-ada . . . [Element_Type]
+//                             ^^^^^ reference scip-ada . Generics . Stack#
+//                                               ^^^^^^^^^^^^ reference scip-ada . Generics . [Element_Type]
      function Is_Empty (S : Stack) return Boolean;
-//            ^^^^^^^^ definition scip-ada . . . Is_Empty().
+//            ^^^^^^^^ definition scip-ada . Generics . Is_Empty().
 //            kind Function
-//            documentation
-//            > function Is_Empty (S : Stack) return Boolean
-//                          ^^^^^ reference scip-ada . . . Stack#
-//                             ^^^^^^^^^^^^^ reference scip-ada . . . Generic_Stack/
+//                          ^^^^^ reference scip-ada . Generics . Stack#
+//                             ^^^^^^^^^^^^^ reference scip-ada . Generics . Generic_Stack/
      function Size (S : Stack) return Natural;
-//      ^^^^^^^^^^^^ reference scip-ada . . . [Element_Type]
-//            ^^^^ definition scip-ada . . . Size().
+//      ^^^^^^^^^^^^ reference scip-ada . Generics . [Element_Type]
+//            ^^^^ definition scip-ada . Generics . Size().
 //            kind Function
-//            documentation
-//            > function Size (S : Stack) return Natural
-//                      ^^^^^ reference scip-ada . . . Stack#
-//                             ^^^^^ reference scip-ada . . . Stack#
-//                                               ^^^^^^^^^^^^ reference scip-ada . . . [Element_Type]
+//                      ^^^^^ reference scip-ada . Generics . Stack#
+//                             ^^^^^ reference scip-ada . Generics . Stack#
+//                                               ^^^^^^^^^^^^ reference scip-ada . Generics . [Element_Type]
   
-//      ^^^^^^^^ reference scip-ada . . . Max_Size.
+//      ^^^^^^^^ reference scip-ada . Generics . Max_Size.
   private
-//      ^^^^ reference scip-ada . . . [Item]
-//              ^ reference scip-ada . . . S#
-//                ^^^^ reference scip-ada . . . Data.
-//                      ^ reference scip-ada . . . S#
-//                        ^^^ reference scip-ada . . . Top.
+//      ^^^^ reference scip-ada . Generics . [Item]
+//              ^ reference scip-ada . Generics . S#
+//                ^^^^ reference scip-ada . Generics . Data.
+//                      ^ reference scip-ada . Generics . S#
+//                        ^^^ reference scip-ada . Generics . Top.
      type Element_Array is array (1 .. Max_Size) of Element_Type;
-//      ^ reference scip-ada . . . S#
-//        ^^^ reference scip-ada . . . Top.
-//        ^^^^^^^^^^^^^ reference scip-ada . . . Generic_Stack/
-//        ^^^^^^^^^^^^^^^^^^ definition scip-ada . . . Element_Array(2+9)#
+//      ^ reference scip-ada . Generics . S#
+//        ^^^ reference scip-ada . Generics . Top.
+//        ^^^^^^^^^^^^^ reference scip-ada . Generics . Generic_Stack/
+//        ^^^^^^^^^^^^^^^^^^ definition scip-ada . Generics . `Element_Array(2+9)`#
 //        kind Type
-//               ^ reference scip-ada . . . S#
-//                 ^^^ reference scip-ada . . . Top.
-//                                     ^^^^^^^^ reference scip-ada . . . Max_Size.
-//                                                  ^^^^^^^^^^^^ reference scip-ada . . . [Element_Type]
+//               ^ reference scip-ada . Generics . S#
+//                 ^^^ reference scip-ada . Generics . Top.
+//                                     ^^^^^^^^ reference scip-ada . Generics . Max_Size.
+//                                                  ^^^^^^^^^^^^ reference scip-ada . Generics . [Element_Type]
   
-//       ^^^ reference scip-ada . . . Pop().
-//          ^^^ reference scip-ada . . . Pop().
-//                  ^^^^^ reference scip-ada . . . Stack#
+//       ^^^ reference scip-ada . Generics . Pop().
+//          ^^^ reference scip-ada . Generics . Pop().
+//                  ^^^^^ reference scip-ada . Generics . Stack#
      type Stack is record
-//        ^^^^^ definition scip-ada . . . Stack#
+//        ^^^^^ definition scip-ada . Generics . Stack#
 //        kind Class
         Data : Element_Array;
-//      ^^^^ definition scip-ada . . . Data.
+//      ^^^^ definition scip-ada . Generics . Data.
 //      kind Variable
-//             ^^^^^^^^^^^^^^^^^^ reference scip-ada . . . Element_Array(2+9)#
-//                          ^^^^^ reference scip-ada . . . Stack#
+//             ^^^^^^^^^^^^^^^^^^ reference scip-ada . Generics . `Element_Array(2+9)`#
+//                          ^^^^^ reference scip-ada . Generics . Stack#
         Top  : Natural := 0;
-//      ^^^ definition scip-ada . . . Top.
+//      ^^^ definition scip-ada . Generics . Top.
 //      kind Variable
-//             ^^^^ reference scip-ada . . . Push().
+//             ^^^^ reference scip-ada . Generics . Push().
      end record;
-//             ^ reference scip-ada . . . S#
-//             ^^^^^ reference scip-ada . . . Stack#
-//               ^^^ reference scip-ada . . . Top.
+//             ^ reference scip-ada . Generics . S#
+//             ^^^^^ reference scip-ada . Generics . Stack#
+//               ^^^ reference scip-ada . Generics . Top.
   end Generic_Stack;
-//    ^^^^^^^^^^^^^ reference scip-ada . . . Generic_Stack/
-//       ^^^^^^^^ reference scip-ada . . . Is_Empty().
-//              ^^^^ reference scip-ada . . . Push().
-//               ^^^^^^^^ reference scip-ada . . . Is_Empty().
-//                 ^^^^^^^^^^^^^ reference scip-ada . . . Generic_Stack/
+//    ^^^^^^^^^^^^^ reference scip-ada . Generics . Generic_Stack/
+//       ^^^^^^^^ reference scip-ada . Generics . Is_Empty().
+//              ^^^^ reference scip-ada . Generics . Push().
+//               ^^^^^^^^ reference scip-ada . Generics . Is_Empty().
+//                 ^^^^^^^^^^^^^ reference scip-ada . Generics . Generic_Stack/
   

--- a/tests/fixtures/generics/snapshot/src/generics_main.adb
+++ b/tests/fixtures/generics/snapshot/src/generics_main.adb
@@ -1,78 +1,74 @@
   with Ada.Text_IO;
-//     ^^^ reference scip-ada . . . Ada/
-//         ^^^^^^^ reference scip-ada . . . Text_IO/
+//     ^^^ reference scip-ada . Generics . Ada/
+//         ^^^^^^^ reference scip-ada . Generics . Text_IO/
   with Generic_Stack;
-//     ^^^^^^^^^^^^^ reference scip-ada . . . Generic_Stack/
+//     ^^^^^^^^^^^^^ reference scip-ada . Generics . Generic_Stack/
   
   procedure Generics_Main is
-//          ^^^^^^^^^^^^^ definition scip-ada . . . Generics_Main().
+//          ^^^^^^^^^^^^^ definition scip-ada . Generics . Generics_Main().
 //          kind Function
-//          documentation
-//          > procedure Generics_Main
-//          ^^^^^^^^^^^^^ definition scip-ada . . . Generics_Main().
+//          ^^^^^^^^^^^^^ definition scip-ada . Generics . Generics_Main().
 //          kind Function
-//          documentation
-//          > procedure Generics_Main
      package Int_Stack is new Generic_Stack
-//           ^^^^^^^^^ definition scip-ada . . . Int_Stack/
+//           ^^^^^^^^^ definition scip-ada . Generics . Int_Stack/
 //           kind Namespace
        (Element_Type => Integer,
-//      ^^^^^^^^^^^^ reference scip-ada . . . [Element_Type]
+//      ^^^^^^^^^^^^ reference scip-ada . Generics . [Element_Type]
         Max_Size     => 10);
-//      ^^^^^^^^ reference scip-ada . . . Max_Size.
+//      ^^^^^^^^ reference scip-ada . Generics . Max_Size.
   
      package Char_Stack is new Generic_Stack
-//           ^^^^^^^^^^ definition scip-ada . . . Char_Stack/
+//           ^^^^^^^^^^ definition scip-ada . Generics . Char_Stack/
 //           kind Namespace
        (Element_Type => Character,
         Max_Size     => 5);
   
      S : Int_Stack.Stack;
-//   ^ definition scip-ada . . . S#
+//   ^ definition scip-ada . Generics . S#
 //   kind Struct
-//       ^^^^^^^^^ reference scip-ada . . . Int_Stack/
-//                 ^^^^^ reference scip-ada . . . Stack#
+//       ^^^^^^^^^ reference scip-ada . Generics . Int_Stack/
+//                 ^^^^^ reference scip-ada . Generics . Stack#
      C : Char_Stack.Stack;
-//   ^ definition scip-ada . . . C#
+//   ^ definition scip-ada . Generics . C#
 //   kind Struct
-//       ^^^^^^^^^^ reference scip-ada . . . Char_Stack/
+//       ^^^^^^^^^^ reference scip-ada . Generics . Char_Stack/
   begin
      Int_Stack.Push (S, 42);
-//   ^^^^^^^^^ reference scip-ada . . . Int_Stack/
-//             ^^^^ reference scip-ada . . . Push().
-//                   ^ reference scip-ada . . . S#
+//   ^^^^^^^^^ reference scip-ada . Generics . Int_Stack/
+//             ^^^^ reference scip-ada . Generics . Push().
+//                   ^ reference scip-ada . Generics . S#
      Int_Stack.Push (S, 99);
-//   ^^^^^^^^^ reference scip-ada . . . Int_Stack/
-//                   ^ reference scip-ada . . . S#
+//   ^^^^^^^^^ reference scip-ada . Generics . Int_Stack/
+//                   ^ reference scip-ada . Generics . S#
   
      Char_Stack.Push (C, 'A');
-//   ^^^^^^^^^^ reference scip-ada . . . Char_Stack/
-//                    ^ reference scip-ada . . . C#
+//   ^^^^^^^^^^ reference scip-ada . Generics . Char_Stack/
+//                    ^ reference scip-ada . Generics . C#
   
      Ada.Text_IO.Put_Line ("Int stack size:" & Natural'Image (Int_Stack.Size (S)));
-//               ^^^^^^^^ reference scip-ada . . . Put_Line().
-//                                                            ^^^^^^^^^ reference scip-ada . . . Int_Stack/
-//                                                                      ^^^^ reference scip-ada . . . Size().
-//                                                                            ^ reference scip-ada . . . S#
+//               ^^^^^^^^ reference scip-ada . Generics . Put_Line().
+//                                                            ^^^^^^^^^ reference scip-ada . Generics . Int_Stack/
+//                                                                      ^^^^ reference scip-ada . Generics . Size().
+//                                                                            ^ reference scip-ada . Generics . S#
      Ada.Text_IO.Put_Line ("Char stack empty: " & Boolean'Image (Char_Stack.Is_Empty (C)));
-//                                                               ^^^^^^^^^^ reference scip-ada . . . Char_Stack/
-//                                                                          ^^^^^^^^ reference scip-ada . . . Is_Empty().
-//                                                                                    ^ reference scip-ada . . . C#
+//                                                               ^^^^^^^^^^ reference scip-ada . Generics . Char_Stack/
+//                                                                          ^^^^^^^^ reference scip-ada . Generics . Is_Empty().
+//                                                                                    ^ reference scip-ada . Generics . C#
   
      declare
         Val : Integer;
-//      ^^^ definition scip-ada . . . Val.
+//      ^^^ definition scip-ada . Generics . Val.
 //      kind Variable
      begin
         Int_Stack.Pop (S, Val);
-//      ^^^^^^^^^ reference scip-ada . . . Int_Stack/
-//                ^^^ reference scip-ada . . . Pop().
-//                     ^ reference scip-ada . . . S#
-//                        ^^^ reference scip-ada . . . Val.
+//      ^^^^^^^^^ reference scip-ada . Generics . Int_Stack/
+//                ^^^ reference scip-ada . Generics . Pop().
+//                     ^ reference scip-ada . Generics . S#
+//                        ^^^ reference scip-ada . Generics . Val.
         Ada.Text_IO.Put_Line ("Popped:" & Integer'Image (Val));
-//                                                       ^^^ reference scip-ada . . . Val.
+//                                                       ^^^ reference scip-ada . Generics . Val.
      end;
   end Generics_Main;
-//    ^^^^^^^^^^^^^ reference scip-ada . . . Generics_Main().
-//                 ^^^^^^^^^^^^^ reference scip-ada . . . Generics_Main().
+//    ^^^^^^^^^^^^^ reference scip-ada . Generics . Generics_Main().
+//                 ^^^^^^^^^^^^^ reference scip-ada . Generics . Generics_Main().
   

--- a/tests/fixtures/hello/snapshot/src/hello.adb
+++ b/tests/fixtures/hello/snapshot/src/hello.adb
@@ -1,25 +1,25 @@
   with Ada.Text_IO;
-//     ^^^ reference scip-ada . . . Ada/
-//         ^^^^^^^ reference scip-ada . . . Text_IO/
+//     ^^^ reference scip-ada . Hello . Ada/
+//         ^^^^^^^ reference scip-ada . Hello . Text_IO/
   
   --  Main entry point; prints a greeting message
   procedure Hello is
-//          ^^^^^ definition scip-ada . . . Hello().
+//          ^^^^^ definition scip-ada . Hello . Hello().
 //          kind Function
 //          documentation
-//          > procedure Hello
-//          ^^^^^ definition scip-ada . . . Hello().
+//          > Main entry point; prints a greeting message
+//          ^^^^^ definition scip-ada . Hello . Hello().
 //          kind Function
 //          documentation
-//          > procedure Hello
+//          > Main entry point; prints a greeting message
      Message : constant String := "Hello, World!";
-//   ^^^^^^^ definition scip-ada . . . Message.
+//   ^^^^^^^ definition scip-ada . Hello . Message.
 //   kind Variable
   begin
      Ada.Text_IO.Put_Line (Message);
-//               ^^^^^^^^ reference scip-ada . . . Put_Line().
-//                         ^^^^^^^ reference scip-ada . . . Message.
+//               ^^^^^^^^ reference scip-ada . Hello . Put_Line().
+//                         ^^^^^^^ reference scip-ada . Hello . Message.
   end Hello;
-//    ^^^^^ reference scip-ada . . . Hello().
-//         ^^^^^ reference scip-ada . . . Hello().
+//    ^^^^^ reference scip-ada . Hello . Hello().
+//         ^^^^^ reference scip-ada . Hello . Hello().
   

--- a/tests/fixtures/multi_unit/snapshot/src/multi_main.adb
+++ b/tests/fixtures/multi_unit/snapshot/src/multi_main.adb
@@ -1,43 +1,39 @@
   with Ada.Text_IO;
-//     ^^^ reference scip-ada . . . Ada/
-//         ^^^^^^^ reference scip-ada . . . Text_IO/
+//     ^^^ reference scip-ada . Multi_Unit . Ada/
+//         ^^^^^^^ reference scip-ada . Multi_Unit . Text_IO/
   with Utils;
-//     ^^^^^ reference scip-ada . . . Utils/
+//     ^^^^^ reference scip-ada . Multi_Unit . Utils/
   with Utils.Strings;
-//           ^^^^^^^ reference scip-ada . . . Strings/
+//           ^^^^^^^ reference scip-ada . Multi_Unit . Strings/
   
   procedure Multi_Main is
-//          ^^^^^^^^^^ definition scip-ada . . . Multi_Main().
+//          ^^^^^^^^^^ definition scip-ada . Multi_Unit . Multi_Main().
 //          kind Function
-//          documentation
-//          > procedure Multi_Main
-//          ^^^^^^^^^^ definition scip-ada . . . Multi_Main().
+//          ^^^^^^^^^^ definition scip-ada . Multi_Unit . Multi_Main().
 //          kind Function
-//          documentation
-//          > procedure Multi_Main
      Sum  : constant Integer := Utils.Add (3, 4);
-//   ^^^ definition scip-ada . . . Sum.
+//   ^^^ definition scip-ada . Multi_Unit . Sum.
 //   kind Variable
-//                                    ^^^ reference scip-ada . . . Add().
+//                                    ^^^ reference scip-ada . Multi_Unit . Add().
      Fact : constant Positive := Utils.Factorial (5);
-//   ^^^^ definition scip-ada . . . Fact.
+//   ^^^^ definition scip-ada . Multi_Unit . Fact.
 //   kind Variable
-//                                     ^^^^^^^^^ reference scip-ada . . . Factorial().
+//                                     ^^^^^^^^^ reference scip-ada . Multi_Unit . Factorial().
      Line : constant String := Utils.Strings.Repeat_Char ('-', 20);
-//   ^^^^ definition scip-ada . . . Line.
+//   ^^^^ definition scip-ada . Multi_Unit . Line.
 //   kind Variable
-//                                           ^^^^^^^^^^^ reference scip-ada . . . Repeat_Char().
+//                                           ^^^^^^^^^^^ reference scip-ada . Multi_Unit . Repeat_Char().
   begin
      Ada.Text_IO.Put_Line (Line);
-//               ^^^^^^^^ reference scip-ada . . . Put_Line().
-//                         ^^^^ reference scip-ada . . . Line.
+//               ^^^^^^^^ reference scip-ada . Multi_Unit . Put_Line().
+//                         ^^^^ reference scip-ada . Multi_Unit . Line.
      Ada.Text_IO.Put_Line ("Sum:" & Integer'Image (Sum));
-//                                                 ^^^ reference scip-ada . . . Sum.
+//                                                 ^^^ reference scip-ada . Multi_Unit . Sum.
      Ada.Text_IO.Put_Line ("Fact:" & Positive'Image (Fact));
-//                                                   ^^^^ reference scip-ada . . . Fact.
+//                                                   ^^^^ reference scip-ada . Multi_Unit . Fact.
      Ada.Text_IO.Put_Line (Line);
-//                         ^^^^ reference scip-ada . . . Line.
+//                         ^^^^ reference scip-ada . Multi_Unit . Line.
   end Multi_Main;
-//    ^^^^^^^^^^ reference scip-ada . . . Multi_Main().
-//              ^^^^^^^^^^ reference scip-ada . . . Multi_Main().
+//    ^^^^^^^^^^ reference scip-ada . Multi_Unit . Multi_Main().
+//              ^^^^^^^^^^ reference scip-ada . Multi_Unit . Multi_Main().
   

--- a/tests/fixtures/multi_unit/snapshot/src/utils-strings.adb
+++ b/tests/fixtures/multi_unit/snapshot/src/utils-strings.adb
@@ -1,16 +1,16 @@
   package body Utils.Strings is
-//             ^^^^^ reference scip-ada . . . Utils/
-//                   ^^^^^^^ definition scip-ada . . . Strings/
+//             ^^^^^ reference scip-ada . Multi_Unit . Utils/
+//                   ^^^^^^^ definition scip-ada . Multi_Unit . Strings/
      function Repeat_Char (C : Character; Count : Natural) return String is
-//            ^^^^^^^^^^^ definition scip-ada . . . Repeat_Char().
-//                         ^ definition scip-ada . . . C.
-//                                        ^^^^^ definition scip-ada . . . Count.
+//            ^^^^^^^^^^^ definition scip-ada . Multi_Unit . Repeat_Char().
+//                         ^ definition scip-ada . Multi_Unit . C.
+//                                        ^^^^^ definition scip-ada . Multi_Unit . Count.
         Result : String (1 .. Count) := (others => C);
-//      ^^^^^^ definition scip-ada . . . Result.
+//      ^^^^^^ definition scip-ada . Multi_Unit . Result.
 //      kind Variable
      begin
         return Result;
-//             ^^^^^^ reference scip-ada . . . Result.
+//             ^^^^^^ reference scip-ada . Multi_Unit . Result.
      end Repeat_Char;
   end Utils.Strings;
   

--- a/tests/fixtures/multi_unit/snapshot/src/utils-strings.ads
+++ b/tests/fixtures/multi_unit/snapshot/src/utils-strings.ads
@@ -1,23 +1,17 @@
   package Utils.Strings is
-//        ^^^^^ reference scip-ada . . . Utils/
-//              ^^^^^^^ definition scip-ada . . . Strings/
+//        ^^^^^ reference scip-ada . Multi_Unit . Utils/
+//              ^^^^^^^ definition scip-ada . Multi_Unit . Strings/
 //              kind Namespace
      function Repeat_Char (C : Character; Count : Natural) return String;
-//            ^^^^^^^^^^^ definition scip-ada . . . Repeat_Char().
+//            ^^^^^^^^^^^ definition scip-ada . Multi_Unit . Repeat_Char().
 //            kind Function
-//            documentation
-//            > function Repeat_Char (C : Character; Count : Natural) return String
-//                         ^ definition scip-ada . . . C.
+//                         ^ definition scip-ada . Multi_Unit . C.
 //                         kind Variable
-//                         documentation
-//                         > function Repeat_Char (C : Character; Count : Natural) return String
-//                                        ^^^^^ definition scip-ada . . . Count.
+//                                        ^^^^^ definition scip-ada . Multi_Unit . Count.
 //                                        kind Variable
-//                                        documentation
-//                                        > function Repeat_Char (C : Character; Count : Natural) return String
   end Utils.Strings;
-//          ^^^^^^^ reference scip-ada . . . Strings/
-//                 ^^^^^^^ reference scip-ada . . . Strings/
-//                            ^^^^^ reference scip-ada . . . Count.
-//                                                 ^ reference scip-ada . . . C.
+//          ^^^^^^^ reference scip-ada . Multi_Unit . Strings/
+//                 ^^^^^^^ reference scip-ada . Multi_Unit . Strings/
+//                            ^^^^^ reference scip-ada . Multi_Unit . Count.
+//                                                 ^ reference scip-ada . Multi_Unit . C.
   

--- a/tests/fixtures/multi_unit/snapshot/src/utils.adb
+++ b/tests/fixtures/multi_unit/snapshot/src/utils.adb
@@ -1,16 +1,16 @@
   package body Utils is
-//             ^^^^^ definition scip-ada . . . Utils/
+//             ^^^^^ definition scip-ada . Multi_Unit . Utils/
      function Add (X, Y : Integer) return Integer is
-//            ^^^ definition scip-ada . . . Add().
-//                 ^ definition scip-ada . . . X.
-//                    ^ definition scip-ada . . . Y.
+//            ^^^ definition scip-ada . Multi_Unit . Add().
+//                 ^ definition scip-ada . Multi_Unit . X.
+//                    ^ definition scip-ada . Multi_Unit . Y.
      begin
         return X + Y;
      end Add;
   
      function Factorial (N : Natural) return Positive is
-//            ^^^^^^^^^ definition scip-ada . . . Factorial().
-//                       ^ definition scip-ada . . . N.
+//            ^^^^^^^^^ definition scip-ada . Multi_Unit . Factorial().
+//                       ^ definition scip-ada . Multi_Unit . N.
      begin
         if N <= 1 then
            return 1;

--- a/tests/fixtures/multi_unit/snapshot/src/utils.ads
+++ b/tests/fixtures/multi_unit/snapshot/src/utils.ads
@@ -1,35 +1,25 @@
   package Utils is
-//        ^^^^^ definition scip-ada . . . Utils/
+//        ^^^^^ definition scip-ada . Multi_Unit . Utils/
 //        kind Namespace
      function Add (X, Y : Integer) return Integer;
-//            ^^^ definition scip-ada . . . Add().
+//            ^^^ definition scip-ada . Multi_Unit . Add().
 //            kind Function
-//            documentation
-//            > function Add (X, Y : Integer) return Integer
-//                 ^ definition scip-ada . . . X.
+//                 ^ definition scip-ada . Multi_Unit . X.
 //                 kind Variable
-//                 documentation
-//                 > function Add (X, Y : Integer) return Integer
-//                    ^ definition scip-ada . . . Y.
+//                    ^ definition scip-ada . Multi_Unit . Y.
 //                    kind Variable
-//                    documentation
-//                    > function Add (X, Y : Integer) return Integer
      function Factorial (N : Natural) return Positive;
-//    ^^^^^ reference scip-ada . . . Utils/
-//     ^^^^^ reference scip-ada . . . Utils/
-//            ^^^^^^^^^ definition scip-ada . . . Factorial().
+//    ^^^^^ reference scip-ada . Multi_Unit . Utils/
+//     ^^^^^ reference scip-ada . Multi_Unit . Utils/
+//            ^^^^^^^^^ definition scip-ada . Multi_Unit . Factorial().
 //            kind Function
-//            documentation
-//            > function Factorial (N : Natural) return Positive
-//                       ^ definition scip-ada . . . N.
+//                       ^ definition scip-ada . Multi_Unit . N.
 //                       kind Variable
-//                       documentation
-//                       > function Factorial (N : Natural) return Positive
   end Utils;
-//    ^^^^^ reference scip-ada . . . Utils/
-//         ^^^^^ reference scip-ada . . . Utils/
-//             ^ reference scip-ada . . . X.
-//                 ^ reference scip-ada . . . Y.
+//    ^^^^^ reference scip-ada . Multi_Unit . Utils/
+//         ^^^^^ reference scip-ada . Multi_Unit . Utils/
+//             ^ reference scip-ada . Multi_Unit . X.
+//                 ^ reference scip-ada . Multi_Unit . Y.
   
-//       ^^^ reference scip-ada . . . Add().
-//          ^^^ reference scip-ada . . . Add().
+//       ^^^ reference scip-ada . Multi_Unit . Add().
+//          ^^^ reference scip-ada . Multi_Unit . Add().

--- a/tests/fixtures/overloads/snapshot/src/converters.adb
+++ b/tests/fixtures/overloads/snapshot/src/converters.adb
@@ -1,48 +1,48 @@
   with Ada.Text_IO;
-//     ^^^ reference scip-ada . . . Ada/
-//         ^^^^^^^ reference scip-ada . . . Text_IO/
+//     ^^^ reference scip-ada . Overloads . Ada/
+//         ^^^^^^^ reference scip-ada . Overloads . Text_IO/
   
   package body Converters is
-//             ^^^^^^^^^^ definition scip-ada . . . Converters/
+//             ^^^^^^^^^^ definition scip-ada . Overloads . Converters/
      function To_String (Value : Integer) return String is
-//            ^^^^^^^^^ definition scip-ada . . . To_String().
-//                       ^^^^^ definition scip-ada . . . Value.
+//            ^^^^^^^^^ definition scip-ada . Overloads . To_String().
+//                       ^^^^^ definition scip-ada . Overloads . Value.
      begin
         return Integer'Image (Value);
      end To_String;
   
      function To_String (Value : Float) return String is
-//            ^^^^^^^^^ definition scip-ada . . . To_String().
-//                       ^^^^^ definition scip-ada . . . Value.
+//            ^^^^^^^^^ definition scip-ada . Overloads . To_String().
+//                       ^^^^^ definition scip-ada . Overloads . Value.
      begin
         return Float'Image (Value);
      end To_String;
   
      function To_String (Value : Boolean) return String is
-//            ^^^^^^^^^ definition scip-ada . . . To_String().
-//                       ^^^^^ definition scip-ada . . . Value.
+//            ^^^^^^^^^ definition scip-ada . Overloads . To_String().
+//                       ^^^^^ definition scip-ada . Overloads . Value.
      begin
         return Boolean'Image (Value);
      end To_String;
   
      procedure Print (Value : Integer) is
-//             ^^^^^ definition scip-ada . . . Print().
-//                    ^^^^^ definition scip-ada . . . Value.
+//             ^^^^^ definition scip-ada . Overloads . Print().
+//                    ^^^^^ definition scip-ada . Overloads . Value.
      begin
         Ada.Text_IO.Put_Line ("Int: " & To_String (Value));
-//                  ^^^^^^^^ reference scip-ada . . . Put_Line().
+//                  ^^^^^^^^ reference scip-ada . Overloads . Put_Line().
      end Print;
   
      procedure Print (Value : Float) is
-//             ^^^^^ definition scip-ada . . . Print().
-//                    ^^^^^ definition scip-ada . . . Value.
+//             ^^^^^ definition scip-ada . Overloads . Print().
+//                    ^^^^^ definition scip-ada . Overloads . Value.
      begin
         Ada.Text_IO.Put_Line ("Float: " & To_String (Value));
      end Print;
   
      procedure Print (Value : String) is
-//             ^^^^^ definition scip-ada . . . Print().
-//                    ^^^^^ definition scip-ada . . . Value.
+//             ^^^^^ definition scip-ada . Overloads . Print().
+//                    ^^^^^ definition scip-ada . Overloads . Value.
      begin
         Ada.Text_IO.Put_Line ("String: " & Value);
      end Print;

--- a/tests/fixtures/overloads/snapshot/src/converters.ads
+++ b/tests/fixtures/overloads/snapshot/src/converters.ads
@@ -1,54 +1,56 @@
   --  Type conversion and printing utilities
   package Converters is
-//        ^^^^^^^^^^ definition scip-ada . . . Converters/
+//        ^^^^^^^^^^ definition scip-ada . Overloads . Converters/
 //        kind Namespace
+//        documentation
+//        > Type conversion and printing utilities
      --  Convert an integer to its string representation
      function To_String (Value : Integer) return String;
-//            ^^^^^^^^^ definition scip-ada . . . To_String().
+//            ^^^^^^^^^ definition scip-ada . Overloads . To_String().
 //            kind Function
 //            documentation
-//            > function To_String (Value : Integer) return String
-//                       ^^^^^ definition scip-ada . . . Value.
+//            > Convert an integer to its string representation
+//                       ^^^^^ definition scip-ada . Overloads . Value.
 //                       kind Variable
 //                       documentation
-//                       > function To_String (Value : Integer) return String
+//                       > Convert an integer to its string representation
      --  Convert a float to its string representation
-//   ^^^^^^^^^^ reference scip-ada . . . Converters/
+//   ^^^^^^^^^^ reference scip-ada . Overloads . Converters/
      function To_String (Value : Float) return String;
-//   ^^^^^^^^^^ reference scip-ada . . . Converters/
-//                            ^^^^^ reference scip-ada . . . Value.
+//   ^^^^^^^^^^ reference scip-ada . Overloads . Converters/
+//                            ^^^^^ reference scip-ada . Overloads . Value.
      --  Convert a boolean to its string representation
-//   ^^^^^^^^^^ reference scip-ada . . . Converters/
-//       ^^^^^^^^^ reference scip-ada . . . To_String().
-//                ^^^^^^^^^ reference scip-ada . . . To_String().
+//   ^^^^^^^^^^ reference scip-ada . Overloads . Converters/
+//       ^^^^^^^^^ reference scip-ada . Overloads . To_String().
+//                ^^^^^^^^^ reference scip-ada . Overloads . To_String().
      function To_String (Value : Boolean) return String;
   
      --  Print an integer value to standard output
-//                              ^^^^^^^^^^ reference scip-ada . . . Converters/
+//                              ^^^^^^^^^^ reference scip-ada . Overloads . Converters/
      procedure Print (Value : Integer);
-//             ^^^^^ definition scip-ada . . . Print().
+//             ^^^^^ definition scip-ada . Overloads . Print().
 //             kind Function
 //             documentation
-//             > procedure Print (Value : Integer)
-//                          ^^^^^ reference scip-ada . . . Value.
-//                              ^^^^^^^^^^ reference scip-ada . . . Converters/
+//             > Print an integer value to standard output
+//                          ^^^^^ reference scip-ada . Overloads . Value.
+//                              ^^^^^^^^^^ reference scip-ada . Overloads . Converters/
      --  Print a float value to standard output
-//       ^^^^^^^^^ reference scip-ada . . . To_String().
-//                ^^^^^^^^^ reference scip-ada . . . To_String().
-//                              ^^^^^^^^^^ reference scip-ada . . . Converters/
+//       ^^^^^^^^^ reference scip-ada . Overloads . To_String().
+//                ^^^^^^^^^ reference scip-ada . Overloads . To_String().
+//                              ^^^^^^^^^^ reference scip-ada . Overloads . Converters/
      procedure Print (Value : Float);
      --  Print a string value to standard output
-//      ^^^^^^^^^^ reference scip-ada . . . Converters/
-//                 ^^^^^ reference scip-ada . . . Print().
+//      ^^^^^^^^^^ reference scip-ada . Overloads . Converters/
+//                 ^^^^^ reference scip-ada . Overloads . Print().
      procedure Print (Value : String);
-//      ^^^^^^^^^^ reference scip-ada . . . Converters/
-//                 ^^^^^ reference scip-ada . . . Print().
+//      ^^^^^^^^^^ reference scip-ada . Overloads . Converters/
+//                 ^^^^^ reference scip-ada . Overloads . Print().
   end Converters;
-//    ^^^^^^^^^^ reference scip-ada . . . Converters/
-//      ^^^^^^^^^^ reference scip-ada . . . Converters/
-//              ^^^^^^^^^^ reference scip-ada . . . Converters/
-//                 ^^^^^ reference scip-ada . . . Print().
-//                            ^^^^^ reference scip-ada . . . Value.
+//    ^^^^^^^^^^ reference scip-ada . Overloads . Converters/
+//      ^^^^^^^^^^ reference scip-ada . Overloads . Converters/
+//              ^^^^^^^^^^ reference scip-ada . Overloads . Converters/
+//                 ^^^^^ reference scip-ada . Overloads . Print().
+//                            ^^^^^ reference scip-ada . Overloads . Value.
   
-//       ^^^^^^^^^ reference scip-ada . . . To_String().
-//                ^^^^^^^^^ reference scip-ada . . . To_String().
+//       ^^^^^^^^^ reference scip-ada . Overloads . To_String().
+//                ^^^^^^^^^ reference scip-ada . Overloads . To_String().

--- a/tests/fixtures/overloads/snapshot/src/overloads_main.adb
+++ b/tests/fixtures/overloads/snapshot/src/overloads_main.adb
@@ -1,45 +1,41 @@
   with Converters;
-//     ^^^^^^^^^^ reference scip-ada . . . Converters/
+//     ^^^^^^^^^^ reference scip-ada . Overloads . Converters/
   
   procedure Overloads_Main is
-//          ^^^^^^^^^^^^^^ definition scip-ada . . . Overloads_Main().
+//          ^^^^^^^^^^^^^^ definition scip-ada . Overloads . Overloads_Main().
 //          kind Function
-//          documentation
-//          > procedure Overloads_Main
-//          ^^^^^^^^^^^^^^ definition scip-ada . . . Overloads_Main().
+//          ^^^^^^^^^^^^^^ definition scip-ada . Overloads . Overloads_Main().
 //          kind Function
-//          documentation
-//          > procedure Overloads_Main
   begin
      Converters.Print (42);
-//              ^^^^^ reference scip-ada . . . Print().
+//              ^^^^^ reference scip-ada . Overloads . Print().
      Converters.Print (3.14);
-//              ^^^^^ reference scip-ada . . . Print().
+//              ^^^^^ reference scip-ada . Overloads . Print().
      Converters.Print ("hello");
-//              ^^^^^ reference scip-ada . . . Print().
+//              ^^^^^ reference scip-ada . Overloads . Print().
   
      declare
         S1 : constant String := Converters.To_String (100);
-//      ^^ definition scip-ada . . . S1.
+//      ^^ definition scip-ada . Overloads . S1.
 //      kind Variable
-//                                         ^^^^^^^^^ reference scip-ada . . . To_String().
+//                                         ^^^^^^^^^ reference scip-ada . Overloads . To_String().
         S2 : constant String := Converters.To_String (2.718);
-//      ^^ definition scip-ada . . . S2.
+//      ^^ definition scip-ada . Overloads . S2.
 //      kind Variable
-//                                         ^^^^^^^^^ reference scip-ada . . . To_String().
+//                                         ^^^^^^^^^ reference scip-ada . Overloads . To_String().
         S3 : constant String := Converters.To_String (True);
-//      ^^ definition scip-ada . . . S3.
+//      ^^ definition scip-ada . Overloads . S3.
 //      kind Variable
-//                                         ^^^^^^^^^ reference scip-ada . . . To_String().
+//                                         ^^^^^^^^^ reference scip-ada . Overloads . To_String().
      begin
         Converters.Print (S1);
-//                        ^^ reference scip-ada . . . S1.
+//                        ^^ reference scip-ada . Overloads . S1.
         Converters.Print (S2);
-//                        ^^ reference scip-ada . . . S2.
+//                        ^^ reference scip-ada . Overloads . S2.
         Converters.Print (S3);
-//                        ^^ reference scip-ada . . . S3.
+//                        ^^ reference scip-ada . Overloads . S3.
      end;
   end Overloads_Main;
-//    ^^^^^^^^^^^^^^ reference scip-ada . . . Overloads_Main().
-//                  ^^^^^^^^^^^^^^ reference scip-ada . . . Overloads_Main().
+//    ^^^^^^^^^^^^^^ reference scip-ada . Overloads . Overloads_Main().
+//                  ^^^^^^^^^^^^^^ reference scip-ada . Overloads . Overloads_Main().
   

--- a/tests/fixtures/tagged_types/snapshot/src/shapes.adb
+++ b/tests/fixtures/tagged_types/snapshot/src/shapes.adb
@@ -1,51 +1,51 @@
   with Ada.Text_IO;
-//     ^^^ reference scip-ada . . . Ada/
-//         ^^^^^^^ reference scip-ada . . . Text_IO/
+//     ^^^ reference scip-ada . Tagged_Types . Ada/
+//         ^^^^^^^ reference scip-ada . Tagged_Types . Text_IO/
   
   package body Shapes is
-//             ^^^^^^ definition scip-ada . . . Shapes/
+//             ^^^^^^ definition scip-ada . Tagged_Types . Shapes/
      procedure Move (S : in out Shape; DX, DY : Float) is
-//             ^^^^ definition scip-ada . . . Move().
-//                   ^ definition scip-ada . . . S#
-//                              ^^^^^ reference scip-ada . . . Shape#
-//                                     ^^ definition scip-ada . . . DX.
-//                                         ^^ definition scip-ada . . . DY.
+//             ^^^^ definition scip-ada . Tagged_Types . Move().
+//                   ^ definition scip-ada . Tagged_Types . S#
+//                              ^^^^^ reference scip-ada . Tagged_Types . Shape#
+//                                     ^^ definition scip-ada . Tagged_Types . DX.
+//                                         ^^ definition scip-ada . Tagged_Types . DY.
      begin
         S.X := S.X + DX;
-//        ^ reference scip-ada . . . X.
+//        ^ reference scip-ada . Tagged_Types . X.
         S.Y := S.Y + DY;
-//        ^ reference scip-ada . . . Y.
+//        ^ reference scip-ada . Tagged_Types . Y.
      end Move;
   
      overriding function Area (S : Circle) return Float is
-//                       ^^^^ definition scip-ada . . . Area().
-//                             ^ definition scip-ada . . . S#
-//                                 ^^^^^^ reference scip-ada . . . Circle#
+//                       ^^^^ definition scip-ada . Tagged_Types . Area().
+//                             ^ definition scip-ada . Tagged_Types . S#
+//                                 ^^^^^^ reference scip-ada . Tagged_Types . Circle#
         Pi : constant Float := 3.14159;
-//      ^^ definition scip-ada . . . Pi.
+//      ^^ definition scip-ada . Tagged_Types . Pi.
 //      kind Variable
      begin
         return Pi * S.Radius * S.Radius;
-//             ^^ reference scip-ada . . . Pi.
-//                    ^^^^^^ reference scip-ada . . . Radius.
+//             ^^ reference scip-ada . Tagged_Types . Pi.
+//                    ^^^^^^ reference scip-ada . Tagged_Types . Radius.
      end Area;
   
      overriding procedure Draw (S : Circle) is
-//                        ^^^^ definition scip-ada . . . Draw().
-//                              ^ definition scip-ada . . . S#
+//                        ^^^^ definition scip-ada . Tagged_Types . Draw().
+//                              ^ definition scip-ada . Tagged_Types . S#
      begin
         Ada.Text_IO.Put_Line ("Drawing circle");
-//                  ^^^^^^^^ reference scip-ada . . . Put_Line().
+//                  ^^^^^^^^ reference scip-ada . Tagged_Types . Put_Line().
      end Draw;
   
      overriding function Area (S : Rectangle) return Float is
-//                       ^^^^ definition scip-ada . . . Area().
-//                             ^ definition scip-ada . . . S#
-//                                 ^^^^^^^^^ reference scip-ada . . . Rectangle#
+//                       ^^^^ definition scip-ada . Tagged_Types . Area().
+//                             ^ definition scip-ada . Tagged_Types . S#
+//                                 ^^^^^^^^^ reference scip-ada . Tagged_Types . Rectangle#
      begin
         return S.Width * S.Height;
-//               ^^^^^ reference scip-ada . . . Width.
-//                         ^^^^^^ reference scip-ada . . . Height.
+//               ^^^^^ reference scip-ada . Tagged_Types . Width.
+//                         ^^^^^^ reference scip-ada . Tagged_Types . Height.
      end Area;
   end Shapes;
   

--- a/tests/fixtures/tagged_types/snapshot/src/shapes.ads
+++ b/tests/fixtures/tagged_types/snapshot/src/shapes.ads
@@ -1,146 +1,153 @@
   --  Geometric shape hierarchy for 2D figures
   package Shapes is
-//        ^^^^^^ definition scip-ada . . . Shapes/
+//        ^^^^^^ definition scip-ada . Tagged_Types . Shapes/
 //        kind Namespace
+//        documentation
+//        > Geometric shape hierarchy for 2D figures
      --  Drawable interface for rendering capability
      type Drawable is interface;
-//        ^^^^^^^^ definition scip-ada . . . Drawable().
+//        ^^^^^^^^ definition scip-ada . Tagged_Types . Drawable().
 //        kind Interface
-//        ^^^^^^^^ definition scip-ada . . . Drawable#
+//        documentation
+//        > Drawable interface for rendering capability
+//        ^^^^^^^^ definition scip-ada . Tagged_Types . Drawable#
 //        kind Interface
+//        documentation
+//        > Drawable interface for rendering capability
   
-//       ^^^^^^ reference scip-ada . . . Shapes/
+//       ^^^^^^ reference scip-ada . Tagged_Types . Shapes/
      --  Draw the object
-//      ^ reference scip-ada . . . S#
-//       ^^^^^^ reference scip-ada . . . Shapes/
-//             ^ reference scip-ada . . . S#
-//               ^ reference scip-ada . . . X.
-//                   ^^ reference scip-ada . . . DX.
-//                            ^ reference scip-ada . . . X.
-//                                      ^ reference scip-ada . . . Y.
+//      ^ reference scip-ada . Tagged_Types . S#
+//       ^^^^^^ reference scip-ada . Tagged_Types . Shapes/
+//             ^ reference scip-ada . Tagged_Types . S#
+//               ^ reference scip-ada . Tagged_Types . X.
+//                   ^^ reference scip-ada . Tagged_Types . DX.
+//                            ^ reference scip-ada . Tagged_Types . X.
+//                                      ^ reference scip-ada . Tagged_Types . Y.
      procedure Draw (D : Drawable) is abstract;
-//      ^ reference scip-ada . . . S#
-//             ^ reference scip-ada . . . S#
-//             ^^^^ definition scip-ada . . . Draw().
+//      ^ reference scip-ada . Tagged_Types . S#
+//             ^ reference scip-ada . Tagged_Types . S#
+//             ^^^^ definition scip-ada . Tagged_Types . Draw().
 //             kind Function
-//             documentation
-//             > procedure Draw (D : Drawable)
-//             ^^^^^^^^ reference scip-ada . . . Drawable().
-//               ^ reference scip-ada . . . Y.
-//                   ^ definition scip-ada . . . D#
+//             ^^^^^^^^ reference scip-ada . Tagged_Types . Drawable().
+//               ^ reference scip-ada . Tagged_Types . Y.
+//                   ^ definition scip-ada . Tagged_Types . D#
 //                   kind Struct
-//                   documentation
-//                   > procedure Draw (D : Drawable)
-//                   ^^ reference scip-ada . . . DY.
-//                       ^^^^^^^^ reference scip-ada . . . Drawable().
+//                   ^^ reference scip-ada . Tagged_Types . DY.
+//                       ^^^^^^^^ reference scip-ada . Tagged_Types . Drawable().
   
-//       ^^^^ reference scip-ada . . . Move().
-//           ^^^^ reference scip-ada . . . Move().
-//                             ^^^^^^ reference scip-ada . . . Shapes/
+//       ^^^^ reference scip-ada . Tagged_Types . Move().
+//           ^^^^ reference scip-ada . Tagged_Types . Move().
+//                             ^^^^^^ reference scip-ada . Tagged_Types . Shapes/
      --  Base abstract shape with position
      type Shape is abstract tagged record
-//        ^^^^^ definition scip-ada . . . Shape#
+//        ^^^^^ definition scip-ada . Tagged_Types . Shape#
 //        kind Class
-//                                                   ^^^^^^ reference scip-ada . . . Shapes/
+//        documentation
+//        > Base abstract shape with position
+//                                                   ^^^^^^ reference scip-ada . Tagged_Types . Shapes/
         X : Float := 0.0;
-//      ^ definition scip-ada . . . X.
+//      ^ definition scip-ada . Tagged_Types . X.
 //      kind Variable
         Y : Float := 0.0;
-//      ^ definition scip-ada . . . Y.
+//      ^ definition scip-ada . Tagged_Types . Y.
 //      kind Variable
      end record;
-//             ^^^^^ reference scip-ada . . . Shape#
-//                  ^ reference scip-ada . . . S#
-//                             ^ reference scip-ada . . . S#
-//                               ^^^^^^ reference scip-ada . . . Radius.
+//             ^^^^^ reference scip-ada . Tagged_Types . Shape#
+//                  ^ reference scip-ada . Tagged_Types . S#
+//                             ^ reference scip-ada . Tagged_Types . S#
+//                               ^^^^^^ reference scip-ada . Tagged_Types . Radius.
   
-//       ^^^^ reference scip-ada . . . Area().
-//           ^^^^ reference scip-ada . . . Area().
+//       ^^^^ reference scip-ada . Tagged_Types . Area().
+//           ^^^^ reference scip-ada . Tagged_Types . Area().
      --  Compute the area of the shape
      function Area (S : Shape) return Float is abstract;
-//   ^^^^^^ reference scip-ada . . . Shapes/
-//            ^^^^ definition scip-ada . . . Area().
+//   ^^^^^^ reference scip-ada . Tagged_Types . Shapes/
+//            ^^^^ definition scip-ada . Tagged_Types . Area().
 //            kind Method
-//            documentation
-//            > function Area (S : Shape) return Float
-//            ^^^^^ reference scip-ada . . . Shape#
-//                  ^ definition scip-ada . . . S#
+//            ^^^^^ reference scip-ada . Tagged_Types . Shape#
+//                  ^ definition scip-ada . Tagged_Types . S#
 //                  kind Struct
-//                  documentation
-//                  > function Area (S : Shape) return Float
-//                      ^^^^^ reference scip-ada . . . Shape#
-//                                  ^^^^^^ reference scip-ada . . . Circle#
+//                      ^^^^^ reference scip-ada . Tagged_Types . Shape#
+//                                  ^^^^^^ reference scip-ada . Tagged_Types . Circle#
      --  Move the shape by the given delta
      procedure Move (S : in out Shape; DX, DY : Float);
-//             ^^^^ definition scip-ada . . . Move().
+//             ^^^^ definition scip-ada . Tagged_Types . Move().
 //             kind Function
 //             documentation
-//             > procedure Move (S : in out Shape; DX, DY : Float)
-//             ^^^^^ reference scip-ada . . . Shape#
-//             ^^^^^^ reference scip-ada . . . Circle#
-//             ^^^^^^^^^ reference scip-ada . . . Rectangle#
-//                              ^^^^^ reference scip-ada . . . Shape#
-//                                     ^^ definition scip-ada . . . DX.
+//             > Move the shape by the given delta
+//             ^^^^^ reference scip-ada . Tagged_Types . Shape#
+//             ^^^^^^ reference scip-ada . Tagged_Types . Circle#
+//             ^^^^^^^^^ reference scip-ada . Tagged_Types . Rectangle#
+//                              ^^^^^ reference scip-ada . Tagged_Types . Shape#
+//                                     ^^ definition scip-ada . Tagged_Types . DX.
 //                                     kind Variable
 //                                     documentation
-//                                     > procedure Move (S : in out Shape; DX, DY : Float)
-//                                         ^ reference scip-ada . . . X.
-//                                         ^^ definition scip-ada . . . DY.
+//                                     > Move the shape by the given delta
+//                                         ^ reference scip-ada . Tagged_Types . X.
+//                                         ^^ definition scip-ada . Tagged_Types . DY.
 //                                         kind Variable
 //                                         documentation
-//                                         > procedure Move (S : in out Shape; DX, DY : Float)
-//                                                                   ^ reference scip-ada . . . Y.
+//                                         > Move the shape by the given delta
+//                                                                   ^ reference scip-ada . Tagged_Types . Y.
   
-//       ^^^^ reference scip-ada . . . Draw().
-//           ^^^^ reference scip-ada . . . Draw().
+//       ^^^^ reference scip-ada . Tagged_Types . Draw().
+//           ^^^^ reference scip-ada . Tagged_Types . Draw().
      --  A pointer to any shape
      type Shape_Access is access all Shape'Class;
-//        ^^^^^^^^^^^^^^^^^^ definition scip-ada . . . Shape_Access(10R9)#
+//        ^^^^^^^^^^^^^^^^^^ definition scip-ada . Tagged_Types . `Shape_Access(10R9)`#
 //        kind Type
-//                                   ^^^^^ reference scip-ada . . . Shape#
+//        documentation
+//        > A pointer to any shape
+//                                   ^^^^^ reference scip-ada . Tagged_Types . Shape#
   
      --  A circle with a radius
-//             ^ reference scip-ada . . . S#
-//                       ^ reference scip-ada . . . S#
+//             ^ reference scip-ada . Tagged_Types . S#
+//                       ^ reference scip-ada . Tagged_Types . S#
      type Circle is new Shape and Drawable with record
-//       ^^^^ reference scip-ada . . . Area().
-//        ^^^^^^ definition scip-ada . . . Circle#
+//       ^^^^ reference scip-ada . Tagged_Types . Area().
+//        ^^^^^^ definition scip-ada . Tagged_Types . Circle#
 //        kind Class
-//           ^^^^ reference scip-ada . . . Area().
-//                      ^^^^^ reference scip-ada . . . Shape#
-//                                ^^^^^^^^ reference scip-ada . . . Drawable().
+//        documentation
+//        > A circle with a radius
+//        relationship scip-ada . Tagged_Types . Shapes#Drawable# type_definition
+//        relationship scip-ada . Tagged_Types . Shapes#Shape# type_definition
+//           ^^^^ reference scip-ada . Tagged_Types . Area().
+//                      ^^^^^ reference scip-ada . Tagged_Types . Shape#
+//                                ^^^^^^^^ reference scip-ada . Tagged_Types . Drawable().
         Radius : Float := 1.0;
-//    ^^^^^^ reference scip-ada . . . Shapes/
-//      ^^^^^^ definition scip-ada . . . Radius.
+//    ^^^^^^ reference scip-ada . Tagged_Types . Shapes/
+//      ^^^^^^ definition scip-ada . Tagged_Types . Radius.
 //      kind Variable
-//          ^^^^^^ reference scip-ada . . . Shapes/
+//          ^^^^^^ reference scip-ada . Tagged_Types . Shapes/
      end record;
-//             ^^^^^^ reference scip-ada . . . Circle#
+//             ^^^^^^ reference scip-ada . Tagged_Types . Circle#
   
      overriding function Area (S : Circle) return Float;
-//                       ^^^^^^ reference scip-ada . . . Circle#
-//                                 ^^^^^^ reference scip-ada . . . Circle#
+//                       ^^^^^^ reference scip-ada . Tagged_Types . Circle#
+//                                 ^^^^^^ reference scip-ada . Tagged_Types . Circle#
      overriding procedure Draw (S : Circle);
-//                        ^^^^^^ reference scip-ada . . . Circle#
-//                                  ^^^^^^ reference scip-ada . . . Circle#
+//                        ^^^^^^ reference scip-ada . Tagged_Types . Circle#
+//                                  ^^^^^^ reference scip-ada . Tagged_Types . Circle#
   
      type Rectangle is new Shape with record
-//        ^^^^^^^^^ definition scip-ada . . . Rectangle#
+//        ^^^^^^^^^ definition scip-ada . Tagged_Types . Rectangle#
 //        kind Class
-//                         ^^^^^ reference scip-ada . . . Shape#
+//        relationship scip-ada . Tagged_Types . Shapes#Shape# type_definition
+//                         ^^^^^ reference scip-ada . Tagged_Types . Shape#
         Width  : Float := 1.0;
-//      ^^^^^ definition scip-ada . . . Width.
+//      ^^^^^ definition scip-ada . Tagged_Types . Width.
 //      kind Variable
         Height : Float := 1.0;
-//      ^^^^^^ definition scip-ada . . . Height.
+//      ^^^^^^ definition scip-ada . Tagged_Types . Height.
 //      kind Variable
      end record;
-//             ^^^^^^^^^ reference scip-ada . . . Rectangle#
+//             ^^^^^^^^^ reference scip-ada . Tagged_Types . Rectangle#
   
      overriding function Area (S : Rectangle) return Float;
-//                       ^^^^^^^^^ reference scip-ada . . . Rectangle#
-//                                 ^^^^^^^^^ reference scip-ada . . . Rectangle#
+//                       ^^^^^^^^^ reference scip-ada . Tagged_Types . Rectangle#
+//                                 ^^^^^^^^^ reference scip-ada . Tagged_Types . Rectangle#
   end Shapes;
-//    ^^^^^^ reference scip-ada . . . Shapes/
-//          ^^^^^^ reference scip-ada . . . Shapes/
+//    ^^^^^^ reference scip-ada . Tagged_Types . Shapes/
+//          ^^^^^^ reference scip-ada . Tagged_Types . Shapes/
   

--- a/tests/fixtures/tagged_types/snapshot/src/tagged_main.adb
+++ b/tests/fixtures/tagged_types/snapshot/src/tagged_main.adb
@@ -1,72 +1,62 @@
   with Ada.Text_IO;
-//     ^^^ reference scip-ada . . . Ada/
-//         ^^^^^^^ reference scip-ada . . . Text_IO/
+//     ^^^ reference scip-ada . Tagged_Types . Ada/
+//         ^^^^^^^ reference scip-ada . Tagged_Types . Text_IO/
   with Shapes;
-//     ^^^^^^ reference scip-ada . . . Shapes/
+//     ^^^^^^ reference scip-ada . Tagged_Types . Shapes/
   
   procedure Tagged_Main is
-//          ^^^^^^^^^^^ definition scip-ada . . . Tagged_Main().
+//          ^^^^^^^^^^^ definition scip-ada . Tagged_Types . Tagged_Main().
 //          kind Function
-//          documentation
-//          > procedure Tagged_Main
-//          ^^^^^^^^^^^ definition scip-ada . . . Tagged_Main().
+//          ^^^^^^^^^^^ definition scip-ada . Tagged_Types . Tagged_Main().
 //          kind Function
-//          documentation
-//          > procedure Tagged_Main
      C : Shapes.Circle := (X => 0.0, Y => 0.0, Radius => 5.0);
-//   ^ definition scip-ada . . . C#
+//   ^ definition scip-ada . Tagged_Types . C#
 //   kind Struct
-//              ^^^^^^ reference scip-ada . . . Circle#
-//                         ^ reference scip-ada . . . X.
-//                                   ^ reference scip-ada . . . Y.
-//                                             ^^^^^^ reference scip-ada . . . Radius.
+//              ^^^^^^ reference scip-ada . Tagged_Types . Circle#
+//                         ^ reference scip-ada . Tagged_Types . X.
+//                                   ^ reference scip-ada . Tagged_Types . Y.
+//                                             ^^^^^^ reference scip-ada . Tagged_Types . Radius.
      R : Shapes.Rectangle := (X => 1.0, Y => 2.0, Width => 3.0, Height => 4.0);
-//   ^ definition scip-ada . . . R#
+//   ^ definition scip-ada . Tagged_Types . R#
 //   kind Struct
-//              ^^^^^^^^^ reference scip-ada . . . Rectangle#
-//                                                ^^^^^ reference scip-ada . . . Width.
-//                                                              ^^^^^^ reference scip-ada . . . Height.
+//              ^^^^^^^^^ reference scip-ada . Tagged_Types . Rectangle#
+//                                                ^^^^^ reference scip-ada . Tagged_Types . Width.
+//                                                              ^^^^^^ reference scip-ada . Tagged_Types . Height.
   
      procedure Print_Area (S : Shapes.Shape'Class) is
-//             ^^^^^^^^^^ definition scip-ada . . . Print_Area().
+//             ^^^^^^^^^^ definition scip-ada . Tagged_Types . Print_Area().
 //             kind Function
-//             documentation
-//             > procedure Print_Area (S : Shapes.Shape'Class)
-//             ^^^^^^^^^^ definition scip-ada . . . Print_Area().
+//             ^^^^^^^^^^ definition scip-ada . Tagged_Types . Print_Area().
 //             kind Function
-//             documentation
-//             > procedure Print_Area (S : Shapes.Shape'Class)
-//                         ^ definition scip-ada . . . S#
+//                         ^ definition scip-ada . Tagged_Types . S#
 //                         kind Type
-//                         documentation
-//                         > procedure Print_Area (S : Shapes.Shape'Class)
-//                                    ^^^^^ reference scip-ada . . . Shape#
+//                                    ^^^^^ reference scip-ada . Tagged_Types . Shape#
      begin
         Ada.Text_IO.Put_Line ("Area:" & Float'Image (Shapes.Area (S)));
-//                  ^^^^^^^^ reference scip-ada . . . Put_Line().
-//                                                          ^^^^ reference scip-ada . . . Area().
-//                                                                ^ reference scip-ada . . . S#
+//                  ^^^^^^^^ reference scip-ada . Tagged_Types . Put_Line().
+//                                                          ^^^^ reference scip-ada . Tagged_Types . Area().
+//                                                                ^ reference scip-ada . Tagged_Types . S#
      end Print_Area;
-//       ^^^^^^^^^^ reference scip-ada . . . Print_Area().
-//                 ^^^^^^^^^^ reference scip-ada . . . Print_Area().
+//       ^^^^^^^^^^ reference scip-ada . Tagged_Types . Print_Area().
+//                 ^^^^^^^^^^ reference scip-ada . Tagged_Types . Print_Area().
   begin
      Print_Area (S => C);
-//   ^^^^^^^^^^ reference scip-ada . . . Print_Area().
-//               ^ reference scip-ada . . . S#
-//                    ^ reference scip-ada . . . C#
+//   ^^^^^^^^^^ reference scip-ada . Tagged_Types . Print_Area().
+//               ^ reference scip-ada . Tagged_Types . S#
+//                    ^ reference scip-ada . Tagged_Types . C#
      Print_Area (S => R);
-//   ^^^^^^^^^^ reference scip-ada . . . Print_Area().
-//               ^ reference scip-ada . . . S#
-//                    ^ reference scip-ada . . . R#
+//   ^^^^^^^^^^ reference scip-ada . Tagged_Types . Print_Area().
+//               ^ reference scip-ada . Tagged_Types . S#
+//                    ^ reference scip-ada . Tagged_Types . R#
   
      Shapes.Move (C, 1.0, 2.0);
-//          ^^^^ reference scip-ada . . . Move().
-//                ^ reference scip-ada . . . C#
+//          ^^^^ reference scip-ada . Tagged_Types . Move().
+//                ^ reference scip-ada . Tagged_Types . C#
      Ada.Text_IO.Put_Line ("Circle moved to:" &
                             Float'Image (C.X) & "," & Float'Image (C.Y));
-//                                       ^ reference scip-ada . . . C#
-//                                                                 ^ reference scip-ada . . . C#
+//                                       ^ reference scip-ada . Tagged_Types . C#
+//                                                                 ^ reference scip-ada . Tagged_Types . C#
   end Tagged_Main;
-//    ^^^^^^^^^^^ reference scip-ada . . . Tagged_Main().
-//               ^^^^^^^^^^^ reference scip-ada . . . Tagged_Main().
+//    ^^^^^^^^^^^ reference scip-ada . Tagged_Types . Tagged_Main().
+//               ^^^^^^^^^^^ reference scip-ada . Tagged_Types . Tagged_Main().
   


### PR DESCRIPTION
## Summary

Adds E2E snapshot tests to the CI pipeline and regenerates all fixture snapshots to match current indexer output.

### Changes

- **CI**: Added two Linux-only steps to the existing `build-and-test` job:
  - **Install scip CLI** — downloads `scip` v0.5.1 to `$HOME/bin`
  - **Run E2E snapshot tests** — runs `tests/e2e_test.sh`, which compiles each fixture, indexes with `scip_ada`, generates snapshots, and diffs against committed baselines
- **Snapshots**: Regenerated all 6 fixture snapshots (hello, multi_unit, generics, tagged_types, overloads, ada2022) to match current output (updated symbol paths and documentation annotations)

### Design

The E2E steps are appended to the existing `build-and-test` job (gated with `if: runner.os == 'Linux'`) rather than a separate job, avoiding a redundant full build.