### PR TITLE
fix(release): disable static linking on macOS to fix crt0.o error (#24)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,12 @@ jobs:
         run: alr settings --set dependencies.shared false
 
       - name: Build (release)
+        if: runner.os != 'macOS'
         run: alr build --release
+
+      - name: Build (release, no static link)
+        if: runner.os == 'macOS'
+        run: alr build --release -- -XSTATIC_LINK=no
 
       - name: Verify binary (Unix)
         if: runner.os != 'Windows'

--- a/scip_ada.gpr
+++ b/scip_ada.gpr
@@ -5,6 +5,9 @@ project Scip_Ada is
    type Enrich_Mode is ("yes", "no");
    Enrich : Enrich_Mode := external ("ENRICH", "yes");
 
+   type Static_Link_Mode is ("yes", "no");
+   Static_Link : Static_Link_Mode := external ("STATIC_LINK", "yes");
+
    LAL_Source_Dirs := ();
    case Enrich is
       when "yes" => LAL_Source_Dirs := ("src/lal/");
@@ -29,7 +32,12 @@ project Scip_Ada is
       for Switches ("Ada") use ("-Es"); --  Symbolic traceback
       case Scip_Ada_Config.Build_Profile is
          when "release" =>
-            for Switches ("Ada") use ("-Es", "-static");
+            case Static_Link is
+               when "yes" =>
+                  for Switches ("Ada") use ("-Es", "-static");
+               when "no" =>
+                  for Switches ("Ada") use ("-Es");
+            end case;
          when others =>
             null;
       end case;
@@ -40,9 +48,16 @@ project Scip_Ada is
         ("-lgnarl", "-Wno-overriding-deployment-version");
       case Scip_Ada_Config.Build_Profile is
          when "release" =>
-            for Switches ("Ada") use
-              ("-lgnarl", "-static",
-               "-Wno-overriding-deployment-version");
+            case Static_Link is
+               when "yes" =>
+                  for Switches ("Ada") use
+                    ("-lgnarl", "-static",
+                     "-Wno-overriding-deployment-version");
+               when "no" =>
+                  for Switches ("Ada") use
+                    ("-lgnarl",
+                     "-Wno-overriding-deployment-version");
+            end case;
          when others =>
             null;
       end case;


### PR DESCRIPTION
## Problem

The release workflow fails on `macos-latest` during the link step:

```
ld: library not found for -lcrt0.o
collect2: error: ld returned 1 exit status
gprbuild: link of scip_ada-main.adb failed
```

macOS does not support fully static executables — Apple removed `crt0.o`. The `-static` flag in the GPR linker/binder packages causes the failure on every macOS release build.

**Failed run:** https://github.com/jafreck/scip-ada/actions/runs/23469148880/job/68287874630

Fixes #24

## Changes

### `scip_ada.gpr`
- Add `STATIC_LINK` external variable (defaults to `"yes"`)
- Gate `-static` in both `Binder` and `Linker` packages behind `STATIC_LINK=yes`
- When `STATIC_LINK=no`, omits `-static` while keeping all other flags

### `.github/workflows/release.yml`
- Split the build step: Linux/Windows use `alr build --release` (default static); macOS uses `alr build --release -- -XSTATIC_LINK=no`

## Verification

Tested locally on macOS arm64:
- `alr build --release` → fails with `library not found for -lcrt0.o` (reproduces CI)
- `alr build --release -- -XSTATIC_LINK=no` → succeeds
- `alr build` (dev profile) → unaffected, succeeds as before

## Notes

The macOS binary still links all project libraries (libadalang, gnatcoll, etc.) statically via `.a` archives. Only system libraries (`libSystem`, `libiconv`) remain dynamic — this is the standard approach used by Rust, Go, and other toolchains on macOS.